### PR TITLE
Told vivado to not include DSPs

### DIFF
--- a/scripts/bfasst/synth/vivado.py
+++ b/scripts/bfasst/synth/vivado.py
@@ -94,8 +94,8 @@ class Vivado_SynthesisTool(SynthesisTool):
                 for vf, libname in design.vhdl_libs.items():
                     fp.write("read_vhdl -library " + libname + " " + str(vf) + "\n")
 
-                # Synthesize
-                fp.write("synth_design -top " + design.top + "\n")
+                # Synthesize - do not include any DSP modules in the synthesized design
+                fp.write("synth_design -top " + design.top + " -max_dsp 0" + "\n")
 
                 # Auto-place ports
                 fp.write("place_ports\n")


### PR DESCRIPTION
@jgoeders You mentioned in a meeting a few weeks ago that we could tell vivado to not include DSPs since fasm2bels doesn't support them. I think this is the right way to do it-- I've tested it, and it works. 