### PR TITLE
Fixed typo with Paths

### DIFF
--- a/scripts/bfasst/compare_waveforms/analyze_graph.py
+++ b/scripts/bfasst/compare_waveforms/analyze_graph.py
@@ -10,18 +10,18 @@ from bfasst.config import VIVADO_BIN_PATH
 '''A function to launch the graphs for designs that have already been tested. Mainly meant
 for checking designs that came back unequivalent to see what was wrong with them.'''
 def analyze_graphs(path, module):
-    impl_v = path / module + "_impl.v"
-    viv_impl_v = path / module + "_temp_impl.v"
-    impl_tb = path / module + "_impl_tb.v"
-    reversed_v = path / module + "_reversed.v"
-    viv_reversed_v = path / module + "_temp_reversed.v"
-    reversed_tb = path / module + "_reversed_tb.v"
-    impl_vcd = path / module + "_impl.vcd"
-    reversed_vcd = path / module + "_reversed.vcd"
-    impl_tcl = path / module + "_impl.tcl"
-    reversed_tcl = path / module + "_reversed.tcl"
-    impl_fst = path / module + "_impl.vcd.fst"
-    reversed_fst = path / module + "_reversed.vcd.fst"
+    impl_v = path / (module + "_impl.v")
+    viv_impl_v = path / (module + "_temp_impl.v")
+    impl_tb = path / (module + "_impl_tb.v")
+    reversed_v = path / (module + "_reversed.v")
+    viv_reversed_v = path / (module + "_temp_reversed.v")
+    reversed_tb = path / (module + "_reversed_tb.v")
+    impl_vcd = path / (module + "_impl.vcd")
+    reversed_vcd = path / (module + "_reversed.vcd")
+    impl_tcl = path / (module + "_impl.tcl")
+    reversed_tcl = path / (module + "_reversed.tcl")
+    impl_fst = path / (module + "_impl.vcd.fst")
+    reversed_fst = path / (module + "_reversed.vcd.fst")
     diff = path / "diff.txt"
     parsed = path / "parsed_diff.txt"
     run_vivado = bfasst.paths.ROOT_PATH / "scripts/bfasst/compare_waveforms/run_vivado.py"


### PR DESCRIPTION
Like we discussed in Slack, there was an order of operations issue with declaring the Paths for the waveform analyzer tool.