### PR TITLE
making build process portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ install_fasm2bels:
 	cd third_party/fasm2bels && make test-py
 
 env:
-	echo "source `pwd`/third_party/rapidwright.sh" > "env.sh"
+	echo ". `pwd`/third_party/rapidwright.sh" > "env.sh"
 	echo "export INTERCHANGE_SCHEMA_PATH=`pwd`/third_party/RapidWright/interchange/fpga-interchange-schema/interchange" >> "env.sh"
 
 install_yosys:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ run_experiment.py: error: the following arguments are required: experiment_yaml
   * ```make packages```
 * Install the Python virtual environment, activate, and install packages:
   * ```make venv```
-  * ```source .venv/bin/activate```
+  * ```. .venv/bin/activate```
   * ```pip install -r requirements.txt```
 
 BFASST can be used to compose different CAD flows from severals tools.  You may want to install these tools:
@@ -41,7 +41,7 @@ BFASST can be used to compose different CAD flows from severals tools.  You may 
 1. Install Rapidwright
    * ```make rapidwright```
    * ```make env```
-   * ```source env.sh```
+   * ```. ./env.sh```
 1. Install fasm2bels
    * ```make install_fasm2bels```
 
@@ -57,8 +57,8 @@ The conformal plugin is currently designed to run conformal on a remote machine 
 
 ### Check Installation
 Finally, test to confirm that everything worked correctly! Run the following:
-1. Add rapidwright to your path: ```source env.sh```
-1. Activate the virual environment: ```source .venv/bin/activate```
+1. Add rapidwright to your path: ```. ./env.sh```
+1. Activate the virual environment: ```. .venv/bin/activate```
 1. Run the flow: ```python scripts/run_design.py examples/basic/add4/ xilinx_conformal_impl```
 
 


### PR DESCRIPTION
source happens to only be available on bash.  Using the . syntax, we can run the install process under dash, which is faster, lighterweight, and available by default on ubuntu.  This is particularly beneficial for CI purposes, but should be applicable to anyone not running bash, ie anything bsd based.
