### PR TITLE
Flow args

### DIFF
--- a/experiments/xilinx_ooc.yaml
+++ b/experiments/xilinx_ooc.yaml
@@ -1,0 +1,6 @@
+designs:
+  - ooc/
+
+flow: xilinx
+
+synth: "-mode out_of_context"

--- a/scripts/bfasst/compare/base.py
+++ b/scripts/bfasst/compare/base.py
@@ -8,8 +8,8 @@ from bfasst.utils import print_color
 
 
 class CompareTool(Tool):
-    def __init__(self, cwd) -> None:
-        super().__init__(cwd)
+    def __init__(self, cwd, flow_args="") -> None:
+        super().__init__(cwd, flow_args)
         self.success_status = Status(CompareStatus.SUCCESS)
 
     # This method should run netlist comparison.  It should return

--- a/scripts/bfasst/compare/conformal.py
+++ b/scripts/bfasst/compare/conformal.py
@@ -33,9 +33,7 @@ class Conformal_CompareTool(CompareTool):
         assert type(vendor) is flows.Vendor
         self.vendor = vendor
 
-    def compare_netlists(self, design, mapping_algorithm, print_to_stdout=True):
-        self.print_to_stdout = print_to_stdout
-
+    def compare_netlists(self, design, mapping_algorithm):
         log_path = self.work_dir / self.LOG_FILE_NAME
 
         generate_comparison = ToolProduct(None, log_path, self.check_compare_status)
@@ -48,12 +46,10 @@ class Conformal_CompareTool(CompareTool):
         )
 
         if status is not None:
-            if self.print_to_stdout:
-                self.print_skipping_compare()
+            self.print_skipping_compare()
             return status
 
-        if self.print_to_stdout:
-            self.print_running_compare()
+        self.print_running_compare()
 
         # Connect to remote machine
         client = self.connect_to_remote_machine()
@@ -110,8 +106,7 @@ class Conformal_CompareTool(CompareTool):
             + "mkdir -p bfasst_work;"
         )
 
-        if self.print_to_stdout:
-            print(cmd)
+        print(cmd)
         (stdin, stdout, stderr) = client.exec_command(
             cmd, timeout=bfasst.config.CONFORMAL_TIMEOUT
         )
@@ -168,8 +163,7 @@ class Conformal_CompareTool(CompareTool):
             + " -NOGui"
         )
 
-        if self.print_to_stdout:
-            print(cmd)
+        print(cmd)
         (stdin, stdout, stderr) = client.exec_command(
             cmd, timeout=bfasst.config.CONFORMAL_TIMEOUT
         )

--- a/scripts/bfasst/compare/conformal.py
+++ b/scripts/bfasst/compare/conformal.py
@@ -1,12 +1,13 @@
 import bfasst
 from bfasst.design import HdlType
 from bfasst.tool import ToolProduct
+from bfasst.status import Status, CompareStatus
+import bfasst.netlist_mapping as netlist_mapping
 import paramiko
 import scp
 import re
 import socket
 import pathlib
-import os
 
 # Suppress paramiko warning
 import warnings
@@ -21,11 +22,9 @@ from bfasst.utils import error
 
 class Conformal_CompareTool(CompareTool):
     TOOL_WORK_DIR = "conformal"
-
     LOG_FILE_NAME = "log.txt"
     DO_FILE_NAME = "compare.do"
     GUI_FILE_NAME = "run_conformal_gui.sh"
-    MAPPING_FILE_NAME = "netlist_mapping.py"
     MAPPED_POINTS_FILE_NAME = "mapped_points.txt"
 
     def __init__(self, cwd, vendor):
@@ -43,7 +42,8 @@ class Conformal_CompareTool(CompareTool):
         status = self.get_prev_run_status(
             tool_products=(generate_comparison,),
             dependency_modified_time=max(
-                pathlib.Path(__file__).stat().st_mtime, design.reversed_netlist_path.stat().st_mtime
+                pathlib.Path(__file__).stat().st_mtime,
+                design.reversed_netlist_path.stat().st_mtime,
             ),
         )
 
@@ -60,15 +60,30 @@ class Conformal_CompareTool(CompareTool):
 
         # Handle libraries
         if self.vendor == flows.Vendor.XILINX:
-            self.remote_libs_dir_path = bfasst.config.CONFORMAL_REMOTE_LIBS_DIR / "xilinx"
-            self.local_libs_paths = list((paths.RESOURCES_PATH / "conformal" / "libraries" / "xilinx").iterdir())
+            self.remote_libs_dir_path = (
+                bfasst.config.CONFORMAL_REMOTE_LIBS_DIR / "xilinx"
+            )
+            self.local_libs_paths = list(
+                (paths.RESOURCES_PATH / "conformal" / "libraries" / "xilinx").iterdir()
+            )
 
             self.local_libs_paths = []
-            yosys_xilinx_libs_path = paths.ROOT_PATH / "third_party/fasm2bels/third_party/prjxray/third_party/yosys/techlibs/xilinx/"            
+            yosys_xilinx_libs_path = (
+                paths.ROOT_PATH
+                / "third_party/fasm2bels/third_party/prjxray/third_party/yosys/techlibs/xilinx/"
+            )
             self.local_libs_paths.append(yosys_xilinx_libs_path / "cells_sim.v")
         elif self.vendor == flows.Vendor.LATTICE:
-            self.remote_libs_dir_path = bfasst.config.CONFORMAL_REMOTE_LIBS_DIR / "lattice"
-            self.local_libs_paths = (paths.RESOURCES_PATH / "conformal" / "libraries" / "lattice" / "sb_ice_syn.v",)
+            self.remote_libs_dir_path = (
+                bfasst.config.CONFORMAL_REMOTE_LIBS_DIR / "lattice"
+            )
+            self.local_libs_paths = (
+                paths.RESOURCES_PATH
+                / "conformal"
+                / "libraries"
+                / "lattice"
+                / "sb_ice_syn.v",
+            )
         else:
             assert False, self.vendor
 
@@ -76,20 +91,16 @@ class Conformal_CompareTool(CompareTool):
         do_file_path = self.create_do_file(design, mapping_algorithm)
 
         # Create or Update the mapped_points file
-        command = None
         if mapping_algorithm == "ccl":
-            command = ("python ~/bfasst/scripts/bfasst/" 
-                + self.MAPPING_FILE_NAME 
-                + " "
-                + str(design.impl_netlist_path)
-                + " "
-                + str(design.reversed_netlist_path)
-                + " > "
-                + self.MAPPED_POINTS_FILE_NAME)
+            netlist_mapping(
+                f"{design.impl_netlist_path}",
+                f"{design.reversed_netlist_path}",
+                self.MAPPED_POINTS_FILE_NAME,
+            )
         else:
-            command = "echo No BYU CCL Mapping > mapped_points.txt"
-        os.system(command)
-        
+            print("No BYU CCL Mapping > mapped_points.txt")
+            return Status(CompareStatus.ERROR)
+
         mapped_points_file_path = self.MAPPED_POINTS_FILE_NAME
 
         # Create remote machine folders
@@ -97,14 +108,18 @@ class Conformal_CompareTool(CompareTool):
             "mkdir -p bfasst_libs;"
             + "mkdir -p bfasst_libs/xilinx;"
             + "mkdir -p bfasst_work;"
-            )
+        )
 
         if self.print_to_stdout:
             print(cmd)
-        (stdin, stdout, stderr) = client.exec_command(cmd, timeout=bfasst.config.CONFORMAL_TIMEOUT)
+        (stdin, stdout, stderr) = client.exec_command(
+            cmd, timeout=bfasst.config.CONFORMAL_TIMEOUT
+        )
 
         # Copy files to remote machine
-        self.copy_files_to_remote_machine(client, design, do_file_path, mapped_points_file_path)
+        self.copy_files_to_remote_machine(
+            client, design, do_file_path, mapped_points_file_path
+        )
 
         # Run conformal remotely
         try:
@@ -139,23 +154,25 @@ class Conformal_CompareTool(CompareTool):
 
     def run_conformal(self, client):
         cmd = (
-                "source "
-                + str(bfasst.config.CONFORMAL_REMOTE_SOURCE_SCRIPT)
-                + ";"
-                + "cd "
-                + str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR)
-                + ";"
-                + str(bfasst.config.CONFORMAL_REMOTE_PATH)
-                + " -Dofile "
-                + self.DO_FILE_NAME
-                + " -Logfile "
-                + self.LOG_FILE_NAME
-                + " -NOGui"
-            )
-        
+            "source "
+            + str(bfasst.config.CONFORMAL_REMOTE_SOURCE_SCRIPT)
+            + ";"
+            + "cd "
+            + str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR)
+            + ";"
+            + str(bfasst.config.CONFORMAL_REMOTE_PATH)
+            + " -Dofile "
+            + self.DO_FILE_NAME
+            + " -Logfile "
+            + self.LOG_FILE_NAME
+            + " -NOGui"
+        )
+
         if self.print_to_stdout:
             print(cmd)
-        (stdin, stdout, stderr) = client.exec_command(cmd, timeout=bfasst.config.CONFORMAL_TIMEOUT)
+        (stdin, stdout, stderr) = client.exec_command(
+            cmd, timeout=bfasst.config.CONFORMAL_TIMEOUT
+        )
 
         stdin.write("yes\n")
 
@@ -175,12 +192,12 @@ class Conformal_CompareTool(CompareTool):
         do_file_path = self.work_dir / self.DO_FILE_NAME
 
         with open(do_file_path, "w") as fp:
-           
 
             fp.write(
                 "read library -Both -sensitive -Verilog "
                 + " ".join(
-                    str(self.remote_libs_dir_path / f.name) for f in self.local_libs_paths
+                    str(self.remote_libs_dir_path / f.name)
+                    for f in self.local_libs_paths
                 )
                 + " -nooptimize\n"
             )
@@ -190,7 +207,7 @@ class Conformal_CompareTool(CompareTool):
             elif design.get_golden_hdl_type() == HdlType.VHDL:
                 src_type = "-Vhdl"
             else:
-                error("Unsupported golden HDL type: ",design.get_golden_hdl_type() )
+                error("Unsupported golden HDL type: ", design.get_golden_hdl_type())
 
             fp.write(
                 "read design "
@@ -206,7 +223,9 @@ class Conformal_CompareTool(CompareTool):
                 + design.reversed_netlist_path.name
                 + " -Verilog -Revised -sensitive -continuousassignment Bidirectional -nokeep_unreach -nosupply\n"
             )
-            fp.write(r"add renaming rule vector_expand %s\[%d\] @1_@2 -Both -map" + "\n")
+            fp.write(
+                r"add renaming rule vector_expand %s\[%d\] @1_@2 -Both -map" + "\n"
+            )
 
             if mapping_algorithm == "ccl":
                 fp.write("set system mode lec -nomap\n")
@@ -214,7 +233,7 @@ class Conformal_CompareTool(CompareTool):
 
             else:
                 fp.write("set system mode lec\n")
-            
+
             fp.write("add compared points -all\n")
             fp.write("compare\n")
             fp.write("report verification\n")
@@ -223,14 +242,21 @@ class Conformal_CompareTool(CompareTool):
         # Create script to run GUI on caedm
         run_gui_path = self.work_dir / self.GUI_FILE_NAME
         with open(run_gui_path, "w") as fp:
-            fp.write("source " + str(bfasst.config.CONFORMAL_REMOTE_SOURCE_SCRIPT) + ";\n")
             fp.write(
-                str(bfasst.config.CONFORMAL_REMOTE_PATH) + " -Dofile " + self.DO_FILE_NAME + "\n"
+                "source " + str(bfasst.config.CONFORMAL_REMOTE_SOURCE_SCRIPT) + ";\n"
+            )
+            fp.write(
+                str(bfasst.config.CONFORMAL_REMOTE_PATH)
+                + " -Dofile "
+                + self.DO_FILE_NAME
+                + "\n"
             )
 
         return do_file_path
 
-    def copy_files_to_remote_machine(self, client, design, do_file_path, mapped_points_file_path):
+    def copy_files_to_remote_machine(
+        self, client, design, do_file_path, mapped_points_file_path
+    ):
         scpClient = scp.SCPClient(client.get_transport())
 
         # Copy library files
@@ -239,18 +265,21 @@ class Conformal_CompareTool(CompareTool):
 
         # Copy do script
         scpClient.put(
-            str(do_file_path), str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR / self.DO_FILE_NAME)
+            str(do_file_path),
+            str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR / self.DO_FILE_NAME),
         )
 
         # Copy gui script
         run_gui_path = self.work_dir / self.GUI_FILE_NAME
         scpClient.put(
-            str(run_gui_path), str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR / self.GUI_FILE_NAME)
+            str(run_gui_path),
+            str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR / self.GUI_FILE_NAME),
         )
 
         # Copy mapped points
         scpClient.put(
-            str(mapped_points_file_path), str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR / self.MAPPED_POINTS_FILE_NAME)
+            str(mapped_points_file_path),
+            str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR / self.MAPPED_POINTS_FILE_NAME),
         )
 
         # Copy top
@@ -264,14 +293,17 @@ class Conformal_CompareTool(CompareTool):
         #    scpClient.put(str(design.full_path / vhdl_file), str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR))
 
         for design_file in design.get_golden_files():
-            scpClient.put(str(design_file), str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR))
+            scpClient.put(
+                str(design_file), str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR)
+            )
 
         # @$(foreach var, $(VERILOG_SUPPORT_FILES),scp $(DESIGN_DIR)/$(var) caedm:$(CONFORMAL_WORK_DIR)/ >> $@;)
         # @$(foreach var, $(VHDL_SUPPORT_FILES),scp $(DESIGN_DIR)/$(var) caedm:$(CONFORMAL_WORK_DIR)/ >> $@;)
 
         # Copy reverse netlist file
         scpClient.put(
-            str(design.reversed_netlist_path), str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR)
+            str(design.reversed_netlist_path),
+            str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR),
         )
 
         scpClient.close()
@@ -279,7 +311,8 @@ class Conformal_CompareTool(CompareTool):
     def copy_log_from_remote_machine(self, client):
         scpClient = scp.SCPClient(client.get_transport())
         scpClient.get(
-            str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR / self.LOG_FILE_NAME), str(self.work_dir)
+            str(bfasst.config.CONFORMAL_REMOTE_WORK_DIR / self.LOG_FILE_NAME),
+            str(self.work_dir),
         )
         scpClient.close()
 

--- a/scripts/bfasst/compare/waveform.py
+++ b/scripts/bfasst/compare/waveform.py
@@ -56,8 +56,7 @@ class Waveform_CompareTool(CompareTool):
 
     """The function that compares the netlists."""
 
-    def compare_netlists(self, design, print_to_stdout=True):
-        self.print_to_stdout = print_to_stdout
+    def compare_netlists(self, design):
         log_path = self.work_dir / self.LOG_FILE_NAME
         generate_comparison = ToolProduct(None, log_path, self.check_compare_status)
         status = self.get_prev_run_status(
@@ -69,12 +68,10 @@ class Waveform_CompareTool(CompareTool):
         )
 
         if status is not None:
-            if self.print_to_stdout:
-                self.print_skipping_compare()
+            self.print_skipping_compare()
             return status
 
-        if self.print_to_stdout:
-            self.print_running_compare()
+        self.print_running_compare()
 
         impl_path = design.impl_netlist_path
         module = impl_path.name[0 : len(impl_path.name) - 7]

--- a/scripts/bfasst/compare/yosys.py
+++ b/scripts/bfasst/compare/yosys.py
@@ -12,8 +12,7 @@ class Yosys_CompareTool(CompareTool):
     TOOL_WORK_DIR = "yosys"
     LOG_FILE_NAME = "log.txt"
     SCRIPT_FILE_NAME = "compare.ys"
-    def compare_netlists(self, design, print_to_stdout=True):
-        self.print_to_stdout = print_to_stdout
+    def compare_netlists(self, design):
         log_path = self.work_dir / self.LOG_FILE_NAME
 
         generate_comparison = ToolProduct(None, log_path, self.check_compare_status)
@@ -25,13 +24,11 @@ class Yosys_CompareTool(CompareTool):
         )
 
         if status is not None:
-            if self.print_to_stdout:
-                self.print_skipping_compare()
+            self.print_skipping_compare()
             return status
 
 
-        if self.print_to_stdout:
-            self.print_running_compare()
+        self.print_running_compare()
 
         # Create Yosys script
         script_file_path = self.create_script_file(design)
@@ -47,8 +44,7 @@ class Yosys_CompareTool(CompareTool):
                 universal_newlines=True,    
             )
             for line in proc.stdout:
-                if self.print_to_stdout:
-                    sys.stdout.write(line)
+                sys.stdout.write(line)
                 fp.write(line)
                 fp.flush()
             proc.communicate()

--- a/scripts/bfasst/compare_waveforms/waveform_alt.py
+++ b/scripts/bfasst/compare_waveforms/waveform_alt.py
@@ -39,8 +39,7 @@ class Waveform_CompareTool(CompareTool):
     CELLS_SIM = str(pathlib.Path.cwd()) + "/third_party/yosys/techlibs/xilinx/cells_sim.v" + "; "
     #Note: Impl design = str(design.impl_netlist_path)
     #Reversed design = str(design.reversed_netlist_path)
-    def compare_netlists(self, design, print_to_stdout=True):
-        self.print_to_stdout = print_to_stdout
+    def compare_netlists(self, design):
         log_path = self.work_dir / self.LOG_FILE_NAME
         generate_comparison = ToolProduct(None, log_path, self.check_compare_status)
         status = self.get_prev_run_status(
@@ -51,12 +50,10 @@ class Waveform_CompareTool(CompareTool):
         )
 
         if status is not None:
-            if self.print_to_stdout:
-                self.print_skipping_compare()
+            self.print_skipping_compare()
             return status
         
-        if self.print_to_stdout:
-            self.print_running_compare()
+        self.print_running_compare()
 
         BASIC_PATH = str(design.impl_netlist_path)[0:len(str(design.impl_netlist_path))-len(str(design.impl_netlist_path.name))]
         print(BASIC_PATH)

--- a/scripts/bfasst/error_injection/base.py
+++ b/scripts/bfasst/error_injection/base.py
@@ -1,9 +1,13 @@
 import abc
 
 from bfasst.tool import Tool
+from bfasst.status import Status, ErrorInjectionStatus
 
 
 class ErrorInjectionTool(Tool):
+    def __init__(self, cwd, flow_args="") -> None:
+        super().__init__(cwd, flow_args)
+        self.success_status = Status(ErrorInjectionStatus.SUCCESS)
 
     # run_error_flows
     # If one or more error flows are specified with an error flow YAML,

--- a/scripts/bfasst/error_injection/error_injector.py
+++ b/scripts/bfasst/error_injection/error_injector.py
@@ -65,8 +65,6 @@ class ErrorInjector_ErrorInjectionTool(ErrorInjectionTool):
                 flow_fcn = self.get_flow_fcn_from_name(flow_name)
                 for itr in range(num_iterations):
                     flow_ret = flow_fcn(netlist_buffer, design)
-                    if flow_ret[0] == Status(ErrorInjectionStatus.FCN_ERROR):
-                        return (Status(ErrorInjectionStatus.FCN_ERROR), None)
                     netlist_buffer = flow_ret[1]
             self.write_buffer_to_netlist(netlist_buffer, corrupt_netlist_path)
             corrupt_netlists.append(corrupt_netlist_path)

--- a/scripts/bfasst/experiment.py
+++ b/scripts/bfasst/experiment.py
@@ -1,11 +1,11 @@
 import yaml
 import zipfile
 import pathlib
-import shutil
-import sys
 
 import bfasst
 from bfasst import paths
+from bfasst.design import Design
+from bfasst.flows import get_flow_fcn_by_name, FlowArgs
 from bfasst.utils import error
 
 class Experiment:
@@ -13,6 +13,7 @@ class Experiment:
         self.post_run = None
         self.yaml_path = yaml_path
         self.name = yaml_path.stem
+        self.flow_args = {k: "" for k in FlowArgs}
 
         # Read experiment YAML
         with open(yaml_path) as fp:
@@ -20,14 +21,14 @@ class Experiment:
 
         # Get the flow fcn pointer
         if not "flow" in experiment_props:
-            bfasst.utils.error("'flow' property missing from experiment YAML", yaml_path)
-        self.flow_fcn = bfasst.flows.get_flow_fcn_by_name(experiment_props["flow"])
+            error("'flow' property missing from experiment YAML", yaml_path)
+        self.flow_fcn = get_flow_fcn_by_name(experiment_props.pop("flow"))
 
         # Create design objects for all designs
         self.design_paths = []
 
         if "designs" in experiment_props:
-            for d in experiment_props["designs"]:
+            for d in experiment_props.pop("designs"):
                 d_path = paths.EXAMPLES_PATH / d
                 if not d_path.is_dir():
                     error("Provided design directory", d_path, "does not exist")
@@ -45,12 +46,8 @@ class Experiment:
                         self.design_paths.append(d_child)
 
 
-        # if "designs" in experiment_props:
-        #     for d in experiment_props["designs"]:
-        #         self.design_paths.append(pathlib.Path(d))
-
         if "design_dirs" in experiment_props:
-            for design_dir in experiment_props["design_dirs"]:
+            for design_dir in experiment_props.pop("design_dirs"):
                 design_dir_path = paths.EXAMPLES_PATH / design_dir
                 if not design_dir_path.is_dir():
                     error(design_dir_path, "is not a directory")
@@ -61,7 +58,7 @@ class Experiment:
                         self.design_paths.append(pathlib.Path(design_dir) / dir_item.name)
 
         if "post_run" in experiment_props:
-            self.post_run = getattr(self, experiment_props["post_run"])
+            self.post_run = getattr(self, experiment_props.pop("post_run"))
 
         # Uniquify
         self.design_paths = list(set(self.design_paths))
@@ -69,12 +66,19 @@ class Experiment:
 
         self.designs = []
         for design_path in self.design_paths:
-            design = bfasst.design.Design(paths.EXAMPLES_PATH / design_path)
+            design = Design(paths.EXAMPLES_PATH / design_path)
             self.designs.append(design)
 
         for design in self.designs:
             if "error_flow" in experiment_props:
-                design.error_flow_yaml = experiment_props["error_flow"] + ".yaml"
+                design.error_flow_yaml = experiment_props.pop("error_flow") + ".yaml"
+
+        for k, v in experiment_props.items():
+            try:
+                key = FlowArgs[k.upper()]
+                self.flow_args[key] = v
+            except KeyError:
+                continue
 
     def get_longest_design_name(self):
         return max([len(str(d.rel_path)) for d in self.designs])

--- a/scripts/bfasst/flows.py
+++ b/scripts/bfasst/flows.py
@@ -4,6 +4,7 @@ import pathlib
 import shutil
 
 import bfasst
+from bfasst.design import Design
 from bfasst.utils import error
 from bfasst.synth.ic2_lse import IC2_LSE_SynthesisTool
 from bfasst.synth.ic2_synplify import IC2_Synplify_SynthesisTool
@@ -89,7 +90,7 @@ def get_flow_fcn_by_name(flow_name):
 
 
 def run_flow(design, flow_type, flow_args, build_dir):
-    assert type(design) is bfasst.design.Design
+    assert type(design) is Design
 
     flow_fcn = get_flow_fcn_by_name(flow_type)
     return flow_fcn(design, flow_args, build_dir)

--- a/scripts/bfasst/flows.py
+++ b/scripts/bfasst/flows.py
@@ -27,9 +27,8 @@ class FlowArgs(Enum):
     SYNTH = 0
     IMPL = 1
     MAP = 2
-    EQUIV = 3
-    CMP = 4     # Currently only accepts "XILINX" or "LATTICE" for Conformal Comparison
-    ERR = 5
+    CMP = 3     # Currently only accepts "XILINX" or "LATTICE" for Conformal Comparison
+    ERR = 4
 
 
 class State(Enum):

--- a/scripts/bfasst/flows.py
+++ b/scripts/bfasst/flows.py
@@ -1,18 +1,16 @@
-from distutils.command.build import build
-import enum
-import abc
-import os
+from enum import Enum
+from enum import unique as enum_unique
 import pathlib
 import shutil
 
 import bfasst
-from bfasst import flows
-from bfasst.utils import TermColor, error
-from enum import Enum
+from bfasst.utils import error
 from bfasst.synth.ic2_lse import IC2_LSE_SynthesisTool
 from bfasst.synth.ic2_synplify import IC2_Synplify_SynthesisTool
 from bfasst.synth.vivado import Vivado_SynthesisTool
 from bfasst.synth.yosys import Yosys_Tech_SynthTool
+from bfasst.opt.ic2_lse import IC2_LSE_OptTool
+from bfasst.opt.ic2_synplify import IC2_Synplify_OptTool
 from bfasst.impl.ic2 import IC2_ImplementationTool
 from bfasst.impl.vivado import Vivado_ImplementationTool
 from bfasst.reverse_bit.xray import XRay_ReverseBitTool
@@ -21,8 +19,6 @@ from bfasst.compare.conformal import Conformal_CompareTool
 from bfasst.compare.yosys import Yosys_CompareTool
 from bfasst.compare.waveform import Waveform_CompareTool
 from bfasst.compare.onespin import OneSpin_CompareTool
-from bfasst.opt.ic2_lse import IC2_LSE_OptTool
-from bfasst.opt.ic2_synplify import IC2_Synplify_OptTool
 from bfasst.error_injection.error_injector import ErrorInjector_ErrorInjectionTool
 
 
@@ -40,8 +36,8 @@ class State(Enum):
     READING_TOOL = 2
 
 
-@enum.unique
-class Flows(enum.Enum):
+@enum_unique
+class Flows(Enum):
     IC2_LSE_CONFORMAL = "IC2_lse_conformal"
     IC2_SYNPLIFY_CONFORMAL = "IC2_synplify_conformal"
     SYNPLIFY_IC2_ONESPIN = "synplify_IC2_icestorm_onespin"
@@ -77,7 +73,7 @@ flow_fcn_map = {
 }
 
 
-class Vendor(enum.Enum):
+class Vendor(Enum):
     LATTICE = 1
     XILINX = 2
 
@@ -95,7 +91,7 @@ def get_flow_fcn_by_name(flow_name):
 def run_flow(design, flow_type, flow_args, build_dir):
     assert type(design) is bfasst.design.Design
 
-    flow_fcn = flows.get_flow_fcn_by_name(flow_type)
+    flow_fcn = get_flow_fcn_by_name(flow_type)
     return flow_fcn(design, flow_args, build_dir)
 
 

--- a/scripts/bfasst/flows.py
+++ b/scripts/bfasst/flows.py
@@ -72,20 +72,17 @@ def flow_ic2_lse_conformal(design, build_dir):
     # Run Icecube2 LSE synthesis
     synth_tool = bfasst.synth.ic2_lse.IC2_LSE_SynthesisTool(build_dir)
     status = synth_tool.create_netlist(design)
-    if status.error:
-        return status
+    
 
     # Run Icecube2 implementations
     impl_tool = bfasst.impl.ic2.IC2_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run icestorm bitstream reversal
     reverse_bit_tool = bfasst.reverse_bit.icestorm.Icestorm_ReverseBitTool(build_dir)
     status = reverse_bit_tool.reverse_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run conformal
     design.compare_golden_files.append(design.top_file)
@@ -99,8 +96,7 @@ def flow_ic2_lse_conformal(design, build_dir):
     status = None
     with bfasst.conformal_lock:
         status = compare_tool.compare_netlists(design)
-    if status.error:
-        return status
+    
 
     return status
 
@@ -113,8 +109,7 @@ def flow_conformal_only(design, build_dir, print_to_stdout=True):
     compare_tool = bfasst.compare.conformal.Conformal_CompareTool(build_dir, Vendor.XILINX)
     with bfasst.conformal_lock:
         status = compare_tool.compare_netlists(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     return status
 
@@ -122,36 +117,30 @@ def flow_xilinx(design, build_dir, print_to_stdout=True):
     # Run Xilinx synthesis and implementation
     synth_tool = bfasst.synth.vivado.Vivado_SynthesisTool(build_dir)
     status = synth_tool.create_netlist(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     impl_tool = bfasst.impl.vivado.Vivado_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
 def flow_xilinx_conformal(design, build_dir, print_to_stdout=True):
     # Run Xilinx synthesis and implementation
     synth_tool = bfasst.synth.vivado.Vivado_SynthesisTool(build_dir)
     status = synth_tool.create_netlist(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     impl_tool = bfasst.impl.vivado.Vivado_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     reverse_bit_tool = bfasst.reverse_bit.xray.XRay_ReverseBitTool(build_dir)
     status = reverse_bit_tool.reverse_bitstream(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     compare_tool = bfasst.compare.conformal.Conformal_CompareTool(build_dir, Vendor.XILINX)
     with bfasst.conformal_lock:
         status = compare_tool.compare_netlists(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     return status
 
@@ -159,26 +148,22 @@ def flow_xilinx_conformal_impl(design, build_dir, print_to_stdout=True):
     # Run Xilinx synthesis and implementation
     synth_tool = bfasst.synth.vivado.Vivado_SynthesisTool(build_dir)
     status = synth_tool.create_netlist(design, print_to_stdout)
-    if status.error:
-        return status
+    
     impl_tool = bfasst.impl.vivado.Vivado_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     # Run X-ray and fasm2bel
     reverse_bit_tool = bfasst.reverse_bit.xray.XRay_ReverseBitTool(build_dir)
     status = reverse_bit_tool.reverse_bitstream(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     # Use conformal to compare against IMPL netlist
     design.golden_sources = [design.impl_netlist_path,]
     compare_tool = bfasst.compare.conformal.Conformal_CompareTool(build_dir, Vendor.XILINX)
     with bfasst.conformal_lock:
         status = compare_tool.compare_netlists(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     return status
 
@@ -186,23 +171,19 @@ def flow_xilinx_yosys_impl(design, build_dir, print_to_stdout=True):
     # Run Xilinx synthesis and implementation
     synth_tool = bfasst.synth.vivado.Vivado_SynthesisTool(build_dir)
     status = synth_tool.create_netlist(design, print_to_stdout)
-    if status.error:
-        return status
+    
     impl_tool = bfasst.impl.vivado.Vivado_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     # Run X-ray and fasm2bel
     reverse_bit_tool = bfasst.reverse_bit.xray.XRay_ReverseBitTool(build_dir)
     status = reverse_bit_tool.reverse_bitstream(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     compare_tool = bfasst.compare.yosys.Yosys_CompareTool(build_dir)
     status = compare_tool.compare_netlists(design, print_to_stdout)
-    if status.error:
-        return status
+    
     
     return status
 
@@ -210,23 +191,19 @@ def flow_xilinx_yosys_waveform(design, build_dir, print_to_stdout=True):
     # Run Xilinx synthesis and implementation
     synth_tool = bfasst.synth.vivado.Vivado_SynthesisTool(build_dir)
     status = synth_tool.create_netlist(design, print_to_stdout)
-    if status.error:
-        return status
+    
     impl_tool = bfasst.impl.vivado.Vivado_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     # Run X-ray and fasm2bel
     reverse_bit_tool = bfasst.reverse_bit.xray.XRay_ReverseBitTool(build_dir)
     status = reverse_bit_tool.reverse_bitstream(design, print_to_stdout)
-    if status.error:
-        return status
+    
 
     compare_tool = bfasst.compare.waveform.Waveform_CompareTool(build_dir)
     status = compare_tool.compare_netlists(design, print_to_stdout)
-    if status.error:
-        return status
+    
     
     return status
 
@@ -235,20 +212,17 @@ def flow_ic2_synplify_conformal(design, build_dir):
     # Run Icecube2 Synplify synthesis
     synth_tool = bfasst.synth.ic2_synplify.IC2_Synplify_SynthesisTool(build_dir)
     status = synth_tool.create_netlist(design)
-    if status.error:
-        return status
+    
 
     # Run Icecube2 implementations
     impl_tool = bfasst.impl.ic2.IC2_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run icestorm bitstream reversal
     reverse_bit_tool = bfasst.reverse_bit.icestorm.Icestorm_ReverseBitTool(build_dir)
     status = reverse_bit_tool.reverse_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run conformal
     design.compare_golden_files.append(design.top_file)
@@ -261,8 +235,7 @@ def flow_ic2_synplify_conformal(design, build_dir):
     compare_tool = bfasst.compare.conformal.Conformal_CompareTool(build_dir)
     with bfasst.conformal_lock:
         status = compare_tool.compare_netlists(design)
-    if status.error:
-        return status
+    
 
     return status
 
@@ -271,20 +244,17 @@ def flow_synplify_ic2_icestorm_onespin(design, build_dir):
     # Run Icecube2 Synplify synthesis
     synth_tool = bfasst.synth.ic2_synplify.IC2_Synplify_SynthesisTool(build_dir)
     status = synth_tool.create_netlist(design)
-    if status.error:
-        return status
+    
 
     # Run Icecube2 implementations
     impl_tool = bfasst.impl.ic2.IC2_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run icestorm bitstream reversal
     reverse_bit_tool = bfasst.reverse_bit.icestorm.Icestorm_ReverseBitTool(build_dir)
     status = reverse_bit_tool.reverse_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run conformal
     design.compare_golden_files.append(design.top_file)
@@ -298,8 +268,7 @@ def flow_synplify_ic2_icestorm_onespin(design, build_dir):
     compare_tool = bfasst.compare.onespin.OneSpin_CompareTool(build_dir)
     with bfasst.onespin_lock:
         status = compare_tool.compare_netlists(design)
-    if status.error:
-        return status
+    
 
     return status
 
@@ -308,8 +277,7 @@ def flow_yosys_tech_lse_conformal(design, build_dir):
     # Run the Yosys synthesizer
     yosys_synth_tool = bfasst.synth.yosys.Yosys_Tech_SynthTool(build_dir)
     status = yosys_synth_tool.create_netlist(design)
-    if status.error:
-        return status
+    
 
     # Now run the LSE synthesizer on the Yosys output
     yosys_netlist_path = design.netlist_path
@@ -318,8 +286,7 @@ def flow_yosys_tech_lse_conformal(design, build_dir):
     design.golden_is_verilog = True
     lse_opt_tool = bfasst.opt.ic2_lse.IC2_LSE_OptTool(build_dir)
     status = lse_opt_tool.create_netlist(design, [str(yosys_netlist_path)], [])
-    if status.error:
-        return status
+    
 
     # Try fixing the netlist LUT inits (there's some issue with how LSE
     #   generates them)
@@ -328,21 +295,18 @@ def flow_yosys_tech_lse_conformal(design, build_dir):
     # Run IC2 Implementation
     impl_tool = bfasst.impl.ic2.IC2_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run icestorm bitstream reversal
     reverse_bit_tool = bfasst.reverse_bit.icestorm.Icestorm_ReverseBitTool(build_dir)
     status = reverse_bit_tool.reverse_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run conformal
     compare_tool = bfasst.compare.conformal.Conformal_CompareTool(build_dir)
     with bfasst.conformal_lock:
         status = compare_tool.compare_netlists(design)
-    if status.error:
-        return status
+    
 
     return status
 
@@ -351,8 +315,7 @@ def flow_yosys_tech_synplify_conformal(design, build_dir):
     # Run the Yosys synthesizer
     yosys_synth_tool = bfasst.synth.yosys.Yosys_Tech_SynthTool(build_dir)
     status = yosys_synth_tool.create_netlist(design)
-    if status.error:
-        return status
+    
 
     # Now run the Synplify synthesizer on the Yosys output
     yosys_netlist_path = design.netlist_path
@@ -361,28 +324,24 @@ def flow_yosys_tech_synplify_conformal(design, build_dir):
     design.golden_is_verilog = True
     synp_opt_tool = bfasst.opt.ic2_synplify.IC2_Synplify_OptTool(build_dir)
     status = synp_opt_tool.create_netlist(design, [str(yosys_netlist_path)], [])
-    if status.error:
-        return status
+    
 
     # Run IC2 Implementation
     impl_tool = bfasst.impl.ic2.IC2_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run icestorm bitstream reversal
     reverse_bit_tool = bfasst.reverse_bit.icestorm.Icestorm_ReverseBitTool(build_dir)
     # Now actually reverse the bitstream
     status = reverse_bit_tool.reverse_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run conformal
     compare_tool = bfasst.compare.conformal.Conformal_CompareTool(build_dir)
     with bfasst.conformal_lock:
         status = compare_tool.compare_netlists(design)
-    if status.error:
-        return status
+    
 
     return status
 
@@ -391,8 +350,7 @@ def flow_yosys_tech_synplify_onespin(design, build_dir):
     # Run the Yosys synthesizer
     yosys_synth_tool = bfasst.synth.yosys.Yosys_Tech_SynthTool(build_dir)
     status = yosys_synth_tool.create_netlist(design)
-    if status.error:
-        return status
+    
 
     # Now run the Synplify synthesizer on the Yosys output
     yosys_netlist_path = design.netlist_path
@@ -401,28 +359,24 @@ def flow_yosys_tech_synplify_onespin(design, build_dir):
     design.golden_is_verilog = True
     synp_opt_tool = bfasst.opt.ic2_synplify.IC2_Synplify_OptTool(build_dir)
     status = synp_opt_tool.create_netlist(design, [str(yosys_netlist_path)], [])
-    if status.error:
-        return status
+    
 
     # Run IC2 Implementation
     impl_tool = bfasst.impl.ic2.IC2_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run icestorm bitstream reversal
     reverse_bit_tool = bfasst.reverse_bit.icestorm.Icestorm_ReverseBitTool(build_dir)
     # Now actually reverse the bitstream
     status = reverse_bit_tool.reverse_bitstream(design)
-    if status.error:
-        return status
+    
 
     design.compare_revised_file = design.reversed_netlist_filename()
     compare_tool = bfasst.compare.onespin.OneSpin_CompareTool(build_dir)
     with bfasst.onespin_lock:
         status = compare_tool.compare_netlists(design)
-    if status.error:
-        return status
+    
 
     return status
 
@@ -434,8 +388,7 @@ def flow_yosys_synplify_error_onespin(design, build_dir):
     # Run the Yosys synthesizer
     yosys_synth_tool = bfasst.synth.yosys.Yosys_Tech_SynthTool(build_dir)
     status = yosys_synth_tool.create_netlist(design)
-    if status.error:
-        return status
+    
 
     # Run error injection
     error_inj_tool = bfasst.error_injection.error_injector.ErrorInjector_ErrorInjectionTool(
@@ -443,8 +396,7 @@ def flow_yosys_synplify_error_onespin(design, build_dir):
     )
     ret = error_inj_tool.run_error_flows(design)
     status = ret[0]
-    if status.error:
-        return status
+    
 
     # Run Synth, impl, and icestorm on the original netlist
     # Now run the Synplify synthesizer on the Yosys output
@@ -454,30 +406,24 @@ def flow_yosys_synplify_error_onespin(design, build_dir):
     design.golden_is_verilog = True
     synp_opt_tool = bfasst.opt.ic2_synplify.IC2_Synplify_OptTool(build_dir)
     status = synp_opt_tool.create_netlist(design, [str(yosys_netlist_path)], [])
-    if status.error:
-        return status
+    
 
     # Run IC2 Implementation
     impl_tool = bfasst.impl.ic2.IC2_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design)
     print(status)
-    if status.error:
-        return status
+    
 
     # Run icestorm bitstream reversal
     reverse_bit_tool = bfasst.reverse_bit.icestorm.Icestorm_ReverseBitTool(build_dir)
     # Now actually reverse the bitstream
     status = reverse_bit_tool.reverse_bitstream(design)
-    if status.error:
-        return status
+    
 
     compare_tool = bfasst.compare.onespin.OneSpin_CompareTool(build_dir)
     design.compare_revised_file = design.reversed_netlist_filename()
     with bfasst.onespin_lock:
         status = compare_tool.compare_netlists(design)
-    if status.error:
-        print("Error status in compare tool!")
-        # return status
 
     # Also use the compare tool to make a compare script for rtl to yosys
     design.compare_revised_file = yosys_netlist_path.name
@@ -486,9 +432,6 @@ def flow_yosys_synplify_error_onespin(design, build_dir):
     compare_tool = bfasst.compare.onespin.OneSpin_CompareTool(build_dir)
     with bfasst.onespin_lock:
         status = compare_tool.compare_netlists(design)
-    if status.error:
-        print("Error status in compare tool!")
-        # return status
 
     # Run synth, impl, icestorm, and onespin on each corrupted netlist
     design.compare_golden_files = [yosys_netlist_path.name]
@@ -504,32 +447,23 @@ def flow_yosys_synplify_error_onespin(design, build_dir):
         shutil.rmtree(synp_opt_tool.work_dir)
         synp_opt_tool = bfasst.opt.ic2_synplify.IC2_Synplify_OptTool(build_dir)
         status = synp_opt_tool.create_netlist(design, [str(netlist)], [])
-        if status.error:
-            return status
 
         # Run IC2 Implementation
         shutil.rmtree(impl_tool.work_dir)
         impl_tool = bfasst.impl.ic2.IC2_ImplementationTool(build_dir)
         status = impl_tool.implement_bitstream(design)
-        if status.error:
-            return status
 
         # Run icestorm bitstream reversal
         shutil.rmtree(reverse_bit_tool.work_dir)
         reverse_bit_tool = bfasst.reverse_bit.icestorm.Icestorm_ReverseBitTool(build_dir)
         # Now actually reverse the bitstream
         status = reverse_bit_tool.reverse_bitstream(design)
-        if status.error:
-            return status
 
         # Run compare to create a onespin tcl for yosys->corrupt reversed netlist
         compare_tool = bfasst.compare.onespin.OneSpin_CompareTool(build_dir)
         design.compare_revised_file = design.reversed_netlist_filename()
         with bfasst.onespin_lock:
             status = compare_tool.compare_netlists(design)
-        if status.error:
-            print("Error status in compare tool!")
-            # return status
 
         # Run compare again so we can check yosys netlist -> corrupt yosys
         #   netlist
@@ -538,8 +472,6 @@ def flow_yosys_synplify_error_onespin(design, build_dir):
         design.compare_revised_file = netlist.name
         with bfasst.onespin_lock:
             status = compare_tool.compare_netlists(design)
-        if status.error:
-            print("Error status in compare tool!")
 
     # Write the python script to run all of the compare tcl scripts
     compare_tool.write_compare_script(design)
@@ -559,20 +491,17 @@ def flow_gather_impl_data(design, build_dir):
     # Run Icecube2 Synplify synthesis
     synth_tool = bfasst.synth.ic2_synplify.IC2_Synplify_SynthesisTool(build_dir)
     status = synth_tool.create_netlist(design)
-    if status.error:
-        return status
+    
 
     # Run Icecube2 implementations
     impl_tool = bfasst.impl.ic2.IC2_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run icestorm bitstream reversal
     reverse_bit_tool = bfasst.reverse_bit.icestorm.Icestorm_ReverseBitTool(build_dir)
     status = reverse_bit_tool.reverse_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Clean up project directories so we get fresh results later
     if synth_tool.opt_tool is not None:
@@ -585,20 +514,17 @@ def flow_gather_impl_data(design, build_dir):
     # Run Icecube2 LSE synthesis
     synth_tool = bfasst.synth.ic2_lse.IC2_LSE_SynthesisTool(build_dir)
     status = synth_tool.create_netlist(design)
-    if status.error:
-        return status
+    
 
     # Run Icecube2 implementations
     impl_tool = bfasst.impl.ic2.IC2_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run icestorm bitstream reversal
     reverse_bit_tool = bfasst.reverse_bit.icestorm.Icestorm_ReverseBitTool(build_dir)
     status = reverse_bit_tool.reverse_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Clean up project directories so we get fresh results later
     if synth_tool.opt_tool is not None:
@@ -611,28 +537,24 @@ def flow_gather_impl_data(design, build_dir):
     # Run the Yosys synthesizer
     yosys_synth_tool = bfasst.synth.yosys.Yosys_Tech_SynthTool(build_dir)
     status = yosys_synth_tool.create_netlist(design)
-    if status.error:
-        return status
+    
 
     # Now run the Synplify synthesizer on the Yosys output
     yosys_netlist_path = design.netlist_path
     synp_opt_tool = bfasst.opt.ic2_synplify.IC2_Synplify_OptTool(build_dir)
     status = synp_opt_tool.create_netlist(design, [str(yosys_netlist_path)], [])
-    if status.error:
-        return status
+    
 
     # Run IC2 Implementation
     impl_tool = bfasst.impl.ic2.IC2_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run icestorm bitstream reversal
     reverse_bit_tool = bfasst.reverse_bit.icestorm.Icestorm_ReverseBitTool(build_dir)
     # Now actually reverse the bitstream
     status = reverse_bit_tool.reverse_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Clean up project directories so we get fresh results later
     shutil.rmtree(synp_opt_tool.work_dir)
@@ -643,15 +565,13 @@ def flow_gather_impl_data(design, build_dir):
     # Run the Yosys synthesizer
     yosys_synth_tool = bfasst.synth.yosys.Yosys_Tech_SynthTool(build_dir)
     status = yosys_synth_tool.create_netlist(design)
-    if status.error:
-        return status
+    
 
     # Now run the LSE synthesizer on the Yosys output
     yosys_netlist_path = design.netlist_path
     lse_opt_tool = bfasst.opt.ic2_lse.IC2_LSE_OptTool(build_dir)
     status = lse_opt_tool.create_netlist(design, [str(yosys_netlist_path)], [])
-    if status.error:
-        return status
+    
 
     # Try fixing the netlist LUT inits (there's some issue with how LSE
     #   generates them)
@@ -660,13 +580,11 @@ def flow_gather_impl_data(design, build_dir):
     # Run IC2 Implementation
     impl_tool = bfasst.impl.ic2.IC2_ImplementationTool(build_dir)
     status = impl_tool.implement_bitstream(design)
-    if status.error:
-        return status
+    
 
     # Run icestorm bitstream reversal
     reverse_bit_tool = bfasst.reverse_bit.icestorm.Icestorm_ReverseBitTool(build_dir)
     status = reverse_bit_tool.reverse_bitstream(design)
-    if status.error:
-        return status
+    
 
     return status

--- a/scripts/bfasst/impl/base.py
+++ b/scripts/bfasst/impl/base.py
@@ -6,8 +6,8 @@ from bfasst.tool import Tool
 
 
 class ImplementationTool(Tool):
-    def __init__(self, cwd) -> None:
-        super().__init__(cwd)
+    def __init__(self, cwd, flow_args="") -> None:
+        super().__init__(cwd, flow_args)
         self.success_status = Status(ImplStatus.SUCCESS)
 
     # This method should run implementation.  It should return

--- a/scripts/bfasst/impl/ic2.py
+++ b/scripts/bfasst/impl/ic2.py
@@ -44,13 +44,9 @@ class IC2_ImplementationTool(ImplementationTool):
 
             # Run implementation
             status = self.run_implement(design, new_netlist_path, tcl_path, log_path)
-            if status.error:
-                return status
 
         # Check implementation log
         status = self.check_impl_status(log_path)
-        if status.error:
-            return status
 
         # Update a file in the main directory with info about impl results
         self.write_to_results_file(design, log_path, need_to_run)

--- a/scripts/bfasst/impl/vivado.py
+++ b/scripts/bfasst/impl/vivado.py
@@ -15,8 +15,7 @@ from bfasst.tool import ToolProduct
 class Vivado_ImplementationTool(ImplementationTool):
     TOOL_WORK_DIR = "vivado_impl"
 
-    def implement_bitstream(self, design, print_to_stdout=True):
-        self.print_to_stdout = print_to_stdout
+    def implement_bitstream(self, design):
 
         log_path = self.work_dir / bfasst.config.IMPL_LOG_NAME
         design.impl_netlist_path = self.cwd / (design.top + "_impl.v")
@@ -33,12 +32,10 @@ class Vivado_ImplementationTool(ImplementationTool):
         )
 
         if status is not None:
-            if self.print_to_stdout:
-                self.print_skipping_impl()
+            self.print_skipping_impl()
             return status
 
-        if self.print_to_stdout:
-            self.print_running_impl()
+        self.print_running_impl()
 
         # Run implementation
         status = self.run_implementation(design, log_path)
@@ -91,9 +88,8 @@ class Vivado_ImplementationTool(ImplementationTool):
                 universal_newlines=True,
             )
             for line in proc.stdout:
-                if self.print_to_stdout:
-                    sys.stdout.write(line)
-                    sys.stdout.flush()
+                sys.stdout.write(line)
+                sys.stdout.flush()
                 fp.write(line)
                 fp.flush()
                 if re.match("\s*ERROR:", line):

--- a/scripts/bfasst/impl/vivado.py
+++ b/scripts/bfasst/impl/vivado.py
@@ -42,13 +42,9 @@ class Vivado_ImplementationTool(ImplementationTool):
 
         # Run implementation
         status = self.run_implementation(design, log_path)
-        if status.error:
-            return status
 
         # Check implementation log
         status = self.check_impl_status(log_path)
-        if status.error:
-            return status
 
         # Update a file in the main directory with info about impl results
         # self.write_to_results_file(design, log_path, need_to_run)

--- a/scripts/bfasst/impl/vivado.py
+++ b/scripts/bfasst/impl/vivado.py
@@ -15,8 +15,13 @@ from bfasst.tool import ToolProduct
 class Vivado_ImplementationTool(ImplementationTool):
     TOOL_WORK_DIR = "vivado_impl"
 
-    def implement_bitstream(self, design):
 
+    def __init__(self, cwd, flow_args="", ooc=False):
+        super().__init__(cwd, flow_args)
+        self.ooc = ooc
+
+
+    def implement_bitstream(self, design):
         log_path = self.work_dir / bfasst.config.IMPL_LOG_NAME
         design.impl_netlist_path = self.cwd / (design.top + "_impl.v")
         design.bitstream_path = self.cwd / (design.top + ".bit")
@@ -66,14 +71,16 @@ class Vivado_ImplementationTool(ImplementationTool):
                 + " [current_fileset]\n"
             )
             fp.write("link_design -part " + bfasst.config.PART + "\n")
-            fp.write("read_xdc " + str(design.constraints_path) + "\n")
+            if not self.ooc:
+                fp.write("read_xdc " + str(design.constraints_path) + "\n")
             fp.write("opt_design\n")
             fp.write("place_design\n")
             fp.write("route_design\n")
             fp.write("write_checkpoint -force -file " + str(self.work_dir / "design.dcp") + "\n")
             # fp.write("write_edif -force -file " + str(design.impl_netlist_path.with_suffix(".edf")) + "\n")
             fp.write("write_verilog -force -file " + str(design.impl_netlist_path) + "\n")
-            fp.write("write_bitstream -force " + str(design.bitstream_path) + "\n")
+            if not self.ooc:
+                fp.write("write_bitstream -force " + str(design.bitstream_path) + "\n")
             # fp.write("write_edif -force {" + str(design.netlist_path) + "}\n")
             fp.write("} ] } { exit 1 }\n")
             fp.write("exit\n")

--- a/scripts/bfasst/netlist_mapping.py
+++ b/scripts/bfasst/netlist_mapping.py
@@ -1,0 +1,321 @@
+# Structural Mapping Algorithm developed for the bfasst project in the BYU CCL
+# Inputs: golden_netlist reversed_netlist
+# Outputs: Mapped Points to be compared (It is focused on IBUFs, OBUFs, and FFs)
+# Follows the format to be used with Conformal Equivalence Checking
+# WARNING: Netlists neet to have the exact same input and output ports!
+# WARNING: Netlists need to have different names for their internal wires!
+# WARNING: All blocks need to only have one output!
+
+from operator import truediv
+from unicodedata import name
+import spydrnet as sdn
+import argparse
+
+class Instance:
+    def __init__(self, instance_name, instance_type, input_wires_names, input_wires_number, 
+    input_wires_matching_number, output_wires_names, output_wires_number, 
+    output_wires_matching_number, other_wires_names, other_wires_number):
+        self.instance_name = instance_name
+        self.instance_type = instance_type
+        self.input_wires_names = input_wires_names
+        self.input_wires_number = input_wires_number
+        self.input_wires_matching_number = input_wires_matching_number
+        self.output_wires_names = output_wires_names
+        self.output_wires_number = output_wires_number
+        self.output_wires_matching_number = output_wires_matching_number
+        self.other_wires_names = other_wires_names
+        self.other_wires_number = other_wires_number
+
+def generate_conformal_mapped_points_file(top_instance, golden_module_name, reversed_module_name):
+    # Loop through each of the ports in the instance
+    for top_port in top_instance.get_ports():
+        if "IN" in str(top_port.direction):
+            if len(top_port.pins) > 1:
+                for pin in top_port.pins:
+                    if pin.wire != None:
+                        input_name = pin.wire.cable.name + "[" + str(pin.wire.index()) + "]"
+                        print("add mapped points " + input_name + " " + input_name 
+                              + " -type PI PI -module " + golden_module_name + " " + reversed_module_name)
+            else:
+                print("add mapped points " + top_port.name + " " + top_port.name + 
+                " -type PI PI -module " + golden_module_name + " " + reversed_module_name)
+        elif "OUT" in str(top_port.direction):
+            if len(top_port.pins) > 1:
+                for pin in top_port.pins:
+                    if pin.wire != None:
+                        input_name = pin.wire.cable.name + "[" + str(pin.wire.index()) + "]"
+                        print("add mapped points " + input_name + " " + input_name 
+                              + " -type PO PO -module " + golden_module_name + " " + reversed_module_name)
+            else:
+                print("add mapped points " + top_port.name + " " + top_port.name + 
+                " -type PO PO -module " + golden_module_name + " " + reversed_module_name)
+        else:
+            print("Unable to recognize port of the top module!")
+
+
+def generate_mapped_points_file(mapped_points, golden_module_name, reversed_module_name):
+    for mapped_pair_and_types in mapped_points:
+        if ((mapped_pair_and_types[2] == "IBUF") and (mapped_pair_and_types[3] == "IBUF")):
+            print("add mapped points " + mapped_pair_and_types[0] + " " + mapped_pair_and_types[1] + 
+            " -type PI PI -module " + golden_module_name + " " + reversed_module_name)
+        elif ((mapped_pair_and_types[2] == "OBUF") and (mapped_pair_and_types[3] == "OBUF")):
+            print("add mapped points " + mapped_pair_and_types[0] + " " + mapped_pair_and_types[1] + 
+            " -type PO PO -module " + golden_module_name + " " + reversed_module_name)
+        elif ((mapped_pair_and_types[2] == "FDRE") and (mapped_pair_and_types[3] == "FDRE")):
+            print("add mapped points " + mapped_pair_and_types[0] + " " + mapped_pair_and_types[1] + 
+            " -type DFF DFF -module " + golden_module_name + " " + reversed_module_name)
+        elif ((("LUT" in mapped_pair_and_types[2]) and ("LUT" in mapped_pair_and_types[3])) or 
+            ((mapped_pair_and_types[2] == "BUFG") and (mapped_pair_and_types[3] == "BUFG"))):
+            pass
+        else:
+            print("Unable to recognize the types of the mapped points!")
+            print("Add more code to the generate_mapped_points_file function in netlist_mapping.py")
+
+def print_mapped_blocks(mapped_points):
+    for mapped_pair in mapped_points:
+        print(mapped_pair[0] + " <-> " + mapped_pair[1])
+        
+def print_netlist(netlist):
+    for instance in netlist:
+        print(instance.instance_name)
+        print(instance.instance_type)
+        print("Inputs")
+        print(instance.input_wires_names)
+        print(instance.input_wires_number)
+        print(instance.input_wires_matching_number)
+        print("Outputs")
+        print(instance.output_wires_names)
+        print(instance.output_wires_number)
+        print(instance.output_wires_matching_number)
+        print("Others")
+        print(instance.other_wires_names)
+        print(instance.other_wires_number, '\n')
+
+def get_netlist(library):
+    netlist = []
+    # Loop through each instance in the current library
+    for instance in library.get_instances():
+        instance_name = instance.name
+        instance_type = instance.reference.name
+        input_wires_names = []
+        output_wires_names = []
+        other_wires_names = []
+        # Loop through each of the pins in the instance                                                          
+        for pin in instance.pins:
+            # Check to see that there is a wire connected to the pin
+            if pin.wire != None:
+                cable_name = pin.wire.cable.name
+                wire_index = str(pin.wire.index())                                                             
+                wire_name = cable_name + "[" + wire_index + "]"
+                if 'I' in pin.inner_pin.port.name:
+                    input_wires_names.append(wire_name)
+                elif 'D' in pin.inner_pin.port.name:
+                    input_wires_names.append(wire_name)
+                elif 'O' in pin.inner_pin.port.name:
+                    output_wires_names.append(wire_name)
+                elif 'Q' in pin.inner_pin.port.name:
+                    output_wires_names.append(wire_name)
+                else:
+                    other_wires_names.append(wire_name)
+        # Getting the lengths
+        input_wires_number = len(input_wires_names)
+        output_wires_number = len(output_wires_names)
+        other_wires_number = len(other_wires_names)
+        # Setting initial matching numbers
+        input_wires_matching_number = 0
+        output_wires_matching_number = 0
+        # Creating new instance object
+        new_instance = Instance(instance_name, instance_type, input_wires_names, input_wires_number, input_wires_matching_number,
+                                output_wires_names, output_wires_number, output_wires_matching_number, other_wires_names, other_wires_number)
+        # Adding instance to the netlist
+        netlist.append(new_instance)
+    return netlist
+
+def main():
+    ################ Parsing command line arguments ################
+    parser = argparse.ArgumentParser()
+    parser.add_argument("golden_netlist")
+    parser.add_argument("reversed_netlist")
+    args = parser.parse_args()
+
+    ################ Fetching Data from Golden netlist ################
+    # Loads the first netlist as intermediate representation (ir1)
+    ir1 = sdn.parse(args.golden_netlist)
+    # Get the first library in the netlist
+    library1 = ir1.libraries[0]
+    golden_netlist = get_netlist(library1)
+
+    ################ Fetching Data from Reversed netlist ################
+    # Loads the second netlist as intermediate representation (ir2)
+    ir2 = sdn.parse(args.reversed_netlist)
+    # Get the first library in the netlist
+    library2 = ir2.libraries[0]
+    reversed_netlist = get_netlist(library2)
+
+    # Print Data Before Mapping
+    # ################ Printing Data from Golden netlist ##################
+    # print("golden_netlist")
+    # print_netlist(golden_netlist)
+
+    # ################ Printing Data from Reversed netlist ################
+    # print("reversed_netlist")
+    # print_netlist(reversed_netlist)
+
+    ########################## Mapping Algorithm ##########################
+    mapped_points = []
+    mapped_blocks = 0
+    progress = True
+    while (((len(reversed_netlist) - 2) != mapped_blocks) and (progress)): # - 2 for G and P (Which should stay unmapped for now)
+        progress = False
+        # Loop through reversed netlist blocks
+        for reversed_instance in reversed_netlist:
+            # If instance has unmatching wires
+            if ((reversed_instance.input_wires_number != reversed_instance.input_wires_matching_number) and 
+            (reversed_instance.output_wires_number != reversed_instance.output_wires_matching_number)):
+                potential_instances = []
+                higher_potential_instances = []
+                saved_instance = None
+                instances_matching = 0
+                # Loop through golden netlist blocks
+                for impl_instance in golden_netlist:
+                    # If instances have same # of wires as input, output, and other
+                    if ((reversed_instance.input_wires_number == impl_instance.input_wires_number) and
+                    (reversed_instance.output_wires_number == impl_instance.output_wires_number) and
+                    (reversed_instance.other_wires_number == impl_instance.other_wires_number)):
+                        # print(reversed_instance.instance_name + " vs " + impl_instance.instance_name)
+                        # Check for matching in inputs
+                        input_wires_matching = 0
+                        for reversed_wire in reversed_instance.input_wires_names:
+                            for impl_wire in impl_instance.input_wires_names:
+                                if (reversed_wire == impl_wire):
+                                    input_wires_matching += 1
+                        # Check for matching in outputs
+                        output_wires_matching = 0
+                        for reversed_wire in reversed_instance.output_wires_names:
+                            for impl_wire in impl_instance.output_wires_names:
+                                if (reversed_wire == impl_wire):
+                                    output_wires_matching += 1
+                        # If they match, add to potential_instances
+                        if ((input_wires_matching > 0) or (output_wires_matching > 0)):
+                            wires_matching = input_wires_matching + output_wires_matching
+                            potential_pair = [impl_instance, wires_matching]
+                            potential_instances.append(potential_pair)
+                # Check if it is only one, if not get the ones with highest number of matching wires
+                if (len(potential_instances) == 1):
+                    instances_matching += 1
+                    saved_instance = potential_instances[0][0]
+                elif (len(potential_instances) > 1):
+                    # Getting the max number of matching wires
+                    max_num = 0
+                    for i in range(len(potential_instances)):
+                        matching_wires = potential_instances[i][1]
+                        if (matching_wires > max_num):
+                            max_num = matching_wires
+                    # Getting the instances with the max number of matching wires
+                    for i in range(len(potential_instances)):
+                        matching_wires = potential_instances[i][1]
+                        if (matching_wires == max_num):
+                            higher_potential_instances.append(potential_instances[i])
+                    # If it is only one save the instance, if not prepare for no mapping!
+                    if (len(higher_potential_instances) == 1):
+                        instances_matching += 1
+                        saved_instance = higher_potential_instances[0][0] 
+                    else:
+                        instances_matching += 2
+                if (instances_matching == 1):  
+                    # Mapping the nets of the block!
+                    maps_performed = 0
+                    # Updating the number of matching wires the first time
+                    if ((reversed_instance.input_wires_matching_number == 0) and (reversed_instance.output_wires_matching_number == 0)):
+                        for reversed_wire in reversed_instance.input_wires_names:
+                                for impl_wire in saved_instance.input_wires_names:
+                                    if (reversed_wire == impl_wire):
+                                        reversed_instance.input_wires_matching_number += 1
+                        for reversed_wire in reversed_instance.output_wires_names:
+                                for impl_wire in saved_instance.output_wires_names:
+                                    if (reversed_wire == impl_wire):
+                                        reversed_instance.output_wires_matching_number += 1
+                        maps_performed += 1
+                    # Update the ummaped wire
+                    if ((reversed_instance.input_wires_number - reversed_instance.input_wires_matching_number) == 1):
+                        # Map Input Net
+                        # Find Input wire in the reversed_instance that is not found in the impl_instance
+                        reversed_input_index = 0
+                        reversed_input_found = False
+                        for i, reversed_wire in enumerate(reversed_instance.input_wires_names):
+                            for impl_wire in saved_instance.input_wires_names:
+                                if (reversed_wire == impl_wire):
+                                    reversed_input_found = True
+                            if (reversed_input_found == False):
+                                reversed_input_index = i
+                            reversed_input_found = False
+                        # Find Input wire in the impl_instance that is not found in the reversed_instance
+                        impl_input_index = 0
+                        impl_input_found = False
+                        for i, impl_wire in enumerate(saved_instance.input_wires_names):
+                            for reversed_wire in reversed_instance.input_wires_names:
+                                if (reversed_wire == impl_wire):
+                                    impl_input_found = True
+                            if (impl_input_found == False):
+                                impl_input_index = i
+                            impl_input_found = False   
+                        # Map the net
+                        old_wire_name = reversed_instance.input_wires_names[reversed_input_index]
+                        new_wire_name = saved_instance.input_wires_names[impl_input_index]
+                        reversed_instance.input_wires_names[reversed_input_index] = new_wire_name
+                        reversed_instance.input_wires_matching_number += 1
+                        # Loop through all the reversed blocks, and if they have inputs or
+                        # outputs equal to the old_wire_name change them to be the new_wire_name
+                        for reversed_block in reversed_netlist:
+                            for i, reversed_block_input_wire in enumerate(reversed_block.input_wires_names):
+                                if (reversed_block_input_wire == old_wire_name):
+                                    reversed_block.input_wires_names[i] = new_wire_name
+                            for i, reversed_block_output_wire in enumerate(reversed_block.output_wires_names):
+                                if (reversed_block_output_wire == old_wire_name):
+                                    reversed_block.output_wires_names[i] = new_wire_name
+                        maps_performed += 1
+                    if ((reversed_instance.output_wires_number - reversed_instance.output_wires_matching_number) == 1):
+                        # Map Output Net
+                        # This should work if all blocks in the netlist only have one output wire!
+                        for i, reversed_wire in enumerate(reversed_instance.output_wires_names):
+                            for impl_wire in saved_instance.output_wires_names:
+                                if (reversed_wire != impl_wire):
+                                    reversed_instance.output_wires_names[i] = impl_wire
+                                    reversed_instance.output_wires_matching_number += 1
+                                    # Loop through all the reversed blocks, and if they have inputs
+                                    # equal to the reversed_wire change them to be the impl_wire
+                                    for reversed_block in reversed_netlist:
+                                        for i, reversed_block_input_wire in enumerate(reversed_block.input_wires_names):
+                                            if (reversed_block_input_wire == reversed_wire):
+                                                reversed_block.input_wires_names[i] = impl_wire
+                        maps_performed += 1
+                    if (maps_performed > 0):
+                        mapped_blocks += 1
+                        progress = True
+                        mapped_pair_and_types = []
+                        mapped_pair_and_types.append(saved_instance.instance_name)
+                        mapped_pair_and_types.append(reversed_instance.instance_name)
+                        mapped_pair_and_types.append(saved_instance.instance_type)
+                        mapped_pair_and_types.append(reversed_instance.instance_type)
+                        mapped_points.append(mapped_pair_and_types)
+
+    # ################ Prints all mapped blocks ################
+    #print_mapped_blocks(mapped_points)
+
+    # ################ Print all mapped instances following conformal syntax ################
+    #generate_mapped_points_file(mapped_points, ir1.top_instance.reference.name, ir2.top_instance.reference.name)
+
+    # ################ Print the Mapped Points File to be used by Conformal ################
+    generate_conformal_mapped_points_file(ir1.top_instance, ir1.top_instance.reference.name, ir2.top_instance.reference.name)
+
+    # Print Data After Mapping
+    # ################ Printing Data from Reversed netlist ################
+    # print("///////////////////////////////// reversed_netlist /////////////////////////////////")
+    # print_netlist(reversed_netlist)
+
+    # ################ Printing Data from Golden netlist ##################
+    # print("///////////////////////////////// golden_netlist /////////////////////////////////")
+    # print_netlist(golden_netlist)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bfasst/netlist_mapping.py
+++ b/scripts/bfasst/netlist_mapping.py
@@ -10,11 +10,30 @@ from operator import truediv
 from unicodedata import name
 import spydrnet as sdn
 import argparse
+from sys import stdout
+
+print_file = None
+
+
+def print_out(*args, **kwargs):
+    global print_file
+    return print(*args, file=print_file, **kwargs)
+
 
 class Instance:
-    def __init__(self, instance_name, instance_type, input_wires_names, input_wires_number, 
-    input_wires_matching_number, output_wires_names, output_wires_number, 
-    output_wires_matching_number, other_wires_names, other_wires_number):
+    def __init__(
+        self,
+        instance_name,
+        instance_type,
+        input_wires_names,
+        input_wires_number,
+        input_wires_matching_number,
+        output_wires_names,
+        output_wires_number,
+        output_wires_matching_number,
+        other_wires_names,
+        other_wires_number,
+    ):
         self.instance_name = instance_name
         self.instance_type = instance_type
         self.input_wires_names = input_wires_names
@@ -26,70 +45,128 @@ class Instance:
         self.other_wires_names = other_wires_names
         self.other_wires_number = other_wires_number
 
-def generate_conformal_mapped_points_file(top_instance, golden_module_name, reversed_module_name):
+
+def generate_conformal_mapped_points_file(
+    top_instance, golden_module_name, reversed_module_name
+):
     # Loop through each of the ports in the instance
     for top_port in top_instance.get_ports():
         if "IN" in str(top_port.direction):
             if len(top_port.pins) > 1:
                 for pin in top_port.pins:
-                    if pin.wire != None:
-                        input_name = pin.wire.cable.name + "[" + str(pin.wire.index()) + "]"
-                        print("add mapped points " + input_name + " " + input_name 
-                              + " -type PI PI -module " + golden_module_name + " " + reversed_module_name)
+                    if pin.wire is not None:
+                        input_name = (
+                            pin.wire.cable.name + "[" + str(pin.wire.index()) + "]"
+                        )
+                        print_out(
+                            f"add mapped points {input_name} {input_name} "
+                            + f"-type PI PI -module {golden_module_name} "
+                            + f"{reversed_module_name}"
+                        )
             else:
-                print("add mapped points " + top_port.name + " " + top_port.name + 
-                " -type PI PI -module " + golden_module_name + " " + reversed_module_name)
+                print_out(
+                    f"add mapped points {top_port.name} {top_port.name}"
+                    + f" -type PI PI -module {golden_module_name} "
+                    + f"{reversed_module_name}"
+                )
         elif "OUT" in str(top_port.direction):
             if len(top_port.pins) > 1:
                 for pin in top_port.pins:
-                    if pin.wire != None:
-                        input_name = pin.wire.cable.name + "[" + str(pin.wire.index()) + "]"
-                        print("add mapped points " + input_name + " " + input_name 
-                              + " -type PO PO -module " + golden_module_name + " " + reversed_module_name)
+                    if pin.wire is not None:
+                        input_name = f"{pin.wire.cable.name}[{pin.wire.index()}]"
+                        print_out(
+                            f"add mapped points {input_name} {input_name}"
+                            + f" -type PO PO -module {golden_module_name} "
+                            + f"{reversed_module_name}"
+                        )
             else:
-                print("add mapped points " + top_port.name + " " + top_port.name + 
-                " -type PO PO -module " + golden_module_name + " " + reversed_module_name)
+                print_out(
+                    f"add mapped points {top_port.name} {top_port.name}"
+                    + f" -type PO PO -module {golden_module_name} "
+                    + f"{reversed_module_name}"
+                )
         else:
-            print("Unable to recognize port of the top module!")
+            print_out("Unable to recognize port of the top module!")
 
 
-def generate_mapped_points_file(mapped_points, golden_module_name, reversed_module_name):
+def generate_mapped_points_file(
+    mapped_points, golden_module_name, reversed_module_name
+):
     for mapped_pair_and_types in mapped_points:
-        if ((mapped_pair_and_types[2] == "IBUF") and (mapped_pair_and_types[3] == "IBUF")):
-            print("add mapped points " + mapped_pair_and_types[0] + " " + mapped_pair_and_types[1] + 
-            " -type PI PI -module " + golden_module_name + " " + reversed_module_name)
-        elif ((mapped_pair_and_types[2] == "OBUF") and (mapped_pair_and_types[3] == "OBUF")):
-            print("add mapped points " + mapped_pair_and_types[0] + " " + mapped_pair_and_types[1] + 
-            " -type PO PO -module " + golden_module_name + " " + reversed_module_name)
-        elif ((mapped_pair_and_types[2] == "FDRE") and (mapped_pair_and_types[3] == "FDRE")):
-            print("add mapped points " + mapped_pair_and_types[0] + " " + mapped_pair_and_types[1] + 
-            " -type DFF DFF -module " + golden_module_name + " " + reversed_module_name)
-        elif ((("LUT" in mapped_pair_and_types[2]) and ("LUT" in mapped_pair_and_types[3])) or 
-            ((mapped_pair_and_types[2] == "BUFG") and (mapped_pair_and_types[3] == "BUFG"))):
+        if (mapped_pair_and_types[2] == "IBUF") and (
+            mapped_pair_and_types[3] == "IBUF"
+        ):
+            print_out(
+                "add mapped points "
+                + mapped_pair_and_types[0]
+                + " "
+                + mapped_pair_and_types[1]
+                + " -type PI PI -module "
+                + golden_module_name
+                + " "
+                + reversed_module_name
+            )
+        elif (mapped_pair_and_types[2] == "OBUF") and (
+            mapped_pair_and_types[3] == "OBUF"
+        ):
+            print_out(
+                "add mapped points "
+                + mapped_pair_and_types[0]
+                + " "
+                + mapped_pair_and_types[1]
+                + " -type PO PO -module "
+                + golden_module_name
+                + " "
+                + reversed_module_name
+            )
+        elif (mapped_pair_and_types[2] == "FDRE") and (
+            mapped_pair_and_types[3] == "FDRE"
+        ):
+            print_out(
+                "add mapped points "
+                + mapped_pair_and_types[0]
+                + " "
+                + mapped_pair_and_types[1]
+                + " -type DFF DFF -module "
+                + golden_module_name
+                + " "
+                + reversed_module_name
+            )
+        elif (
+            ("LUT" in mapped_pair_and_types[2]) and ("LUT" in mapped_pair_and_types[3])
+        ) or (
+            (mapped_pair_and_types[2] == "BUFG")
+            and (mapped_pair_and_types[3] == "BUFG")
+        ):
             pass
         else:
-            print("Unable to recognize the types of the mapped points!")
-            print("Add more code to the generate_mapped_points_file function in netlist_mapping.py")
+            print_out("Unable to recognize the types of the mapped points!")
+            print_out(
+                "Add more code to the generate_mapped_points_file function in netlist_mapping.py"
+            )
+
 
 def print_mapped_blocks(mapped_points):
     for mapped_pair in mapped_points:
-        print(mapped_pair[0] + " <-> " + mapped_pair[1])
-        
+        print_out(mapped_pair[0] + " <-> " + mapped_pair[1])
+
+
 def print_netlist(netlist):
     for instance in netlist:
-        print(instance.instance_name)
-        print(instance.instance_type)
-        print("Inputs")
-        print(instance.input_wires_names)
-        print(instance.input_wires_number)
-        print(instance.input_wires_matching_number)
-        print("Outputs")
-        print(instance.output_wires_names)
-        print(instance.output_wires_number)
-        print(instance.output_wires_matching_number)
-        print("Others")
-        print(instance.other_wires_names)
-        print(instance.other_wires_number, '\n')
+        print_out(instance.instance_name)
+        print_out(instance.instance_type)
+        print_out("Inputs")
+        print_out(instance.input_wires_names)
+        print_out(instance.input_wires_number)
+        print_out(instance.input_wires_matching_number)
+        print_out("Outputs")
+        print_out(instance.output_wires_names)
+        print_out(instance.output_wires_number)
+        print_out(instance.output_wires_matching_number)
+        print_out("Others")
+        print_out(instance.other_wires_names)
+        print_out(instance.other_wires_number, "\n")
+
 
 def get_netlist(library):
     netlist = []
@@ -100,20 +177,20 @@ def get_netlist(library):
         input_wires_names = []
         output_wires_names = []
         other_wires_names = []
-        # Loop through each of the pins in the instance                                                          
+        # Loop through each of the pins in the instance
         for pin in instance.pins:
             # Check to see that there is a wire connected to the pin
             if pin.wire != None:
                 cable_name = pin.wire.cable.name
-                wire_index = str(pin.wire.index())                                                             
+                wire_index = str(pin.wire.index())
                 wire_name = cable_name + "[" + wire_index + "]"
-                if 'I' in pin.inner_pin.port.name:
+                if "I" in pin.inner_pin.port.name:
                     input_wires_names.append(wire_name)
-                elif 'D' in pin.inner_pin.port.name:
+                elif "D" in pin.inner_pin.port.name:
                     input_wires_names.append(wire_name)
-                elif 'O' in pin.inner_pin.port.name:
+                elif "O" in pin.inner_pin.port.name:
                     output_wires_names.append(wire_name)
-                elif 'Q' in pin.inner_pin.port.name:
+                elif "Q" in pin.inner_pin.port.name:
                     output_wires_names.append(wire_name)
                 else:
                     other_wires_names.append(wire_name)
@@ -125,197 +202,299 @@ def get_netlist(library):
         input_wires_matching_number = 0
         output_wires_matching_number = 0
         # Creating new instance object
-        new_instance = Instance(instance_name, instance_type, input_wires_names, input_wires_number, input_wires_matching_number,
-                                output_wires_names, output_wires_number, output_wires_matching_number, other_wires_names, other_wires_number)
+        new_instance = Instance(
+            instance_name,
+            instance_type,
+            input_wires_names,
+            input_wires_number,
+            input_wires_matching_number,
+            output_wires_names,
+            output_wires_number,
+            output_wires_matching_number,
+            other_wires_names,
+            other_wires_number,
+        )
         # Adding instance to the netlist
         netlist.append(new_instance)
     return netlist
 
-def main():
+
+def main(golden_netlist, reversed_netlist, file=stdout):
+    global print_file
+    if file != stdout:
+        print_file = open(file, "w")
+    else:
+        print_file = stdout
+    try:
+        ################ Fetching Data from Golden netlist ################
+        # Loads the first netlist as intermediate representation (ir1)
+        ir1 = sdn.parse(golden_netlist)
+        # Get the first library in the netlist
+        library1 = ir1.libraries[0]
+        golden_netlist = get_netlist(library1)
+
+        ################ Fetching Data from Reversed netlist ################
+        # Loads the second netlist as intermediate representation (ir2)
+        ir2 = sdn.parse(reversed_netlist)
+        # Get the first library in the netlist
+        library2 = ir2.libraries[0]
+        reversed_netlist = get_netlist(library2)
+
+        # Print Data Before Mapping
+        # ################ Printing Data from Golden netlist ##################
+        # print_out("golden_netlist")
+        # print_netlist(golden_netlist)
+
+        # ################ Printing Data from Reversed netlist ################
+        # print_out("reversed_netlist")
+        # print_netlist(reversed_netlist)
+
+        ########################## Mapping Algorithm ##########################
+        mapped_points = []
+        mapped_blocks = 0
+        progress = True
+        while ((len(reversed_netlist) - 2) != mapped_blocks) and (
+            progress
+        ):  # - 2 for G and P (Which should stay unmapped for now)
+            progress = False
+            # Loop through reversed netlist blocks
+            for reversed_instance in reversed_netlist:
+                # If instance has unmatching wires
+                if (
+                    reversed_instance.input_wires_number
+                    != reversed_instance.input_wires_matching_number
+                ) and (
+                    reversed_instance.output_wires_number
+                    != reversed_instance.output_wires_matching_number
+                ):
+                    potential_instances = []
+                    higher_potential_instances = []
+                    saved_instance = None
+                    instances_matching = 0
+                    # Loop through golden netlist blocks
+                    for impl_instance in golden_netlist:
+                        # If instances have same # of wires as input, output, and other
+                        if (
+                            (
+                                reversed_instance.input_wires_number
+                                == impl_instance.input_wires_number
+                            )
+                            and (
+                                reversed_instance.output_wires_number
+                                == impl_instance.output_wires_number
+                            )
+                            and (
+                                reversed_instance.other_wires_number
+                                == impl_instance.other_wires_number
+                            )
+                        ):
+                            # print_out(reversed_instance.instance_name + " vs " + impl_instance.instance_name)
+                            # Check for matching in inputs
+                            input_wires_matching = 0
+                            for reversed_wire in reversed_instance.input_wires_names:
+                                for impl_wire in impl_instance.input_wires_names:
+                                    if reversed_wire == impl_wire:
+                                        input_wires_matching += 1
+                            # Check for matching in outputs
+                            output_wires_matching = 0
+                            for reversed_wire in reversed_instance.output_wires_names:
+                                for impl_wire in impl_instance.output_wires_names:
+                                    if reversed_wire == impl_wire:
+                                        output_wires_matching += 1
+                            # If they match, add to potential_instances
+                            if (input_wires_matching > 0) or (
+                                output_wires_matching > 0
+                            ):
+                                wires_matching = (
+                                    input_wires_matching + output_wires_matching
+                                )
+                                potential_pair = [impl_instance, wires_matching]
+                                potential_instances.append(potential_pair)
+                    # Check if it is only one, if not get the ones with highest number of matching wires
+                    if len(potential_instances) == 1:
+                        instances_matching += 1
+                        saved_instance = potential_instances[0][0]
+                    elif len(potential_instances) > 1:
+                        # Getting the max number of matching wires
+                        max_num = 0
+                        for i in range(len(potential_instances)):
+                            matching_wires = potential_instances[i][1]
+                            if matching_wires > max_num:
+                                max_num = matching_wires
+                        # Getting the instances with the max number of matching wires
+                        for i in range(len(potential_instances)):
+                            matching_wires = potential_instances[i][1]
+                            if matching_wires == max_num:
+                                higher_potential_instances.append(
+                                    potential_instances[i]
+                                )
+                        # If it is only one save the instance, if not prepare for no mapping!
+                        if len(higher_potential_instances) == 1:
+                            instances_matching += 1
+                            saved_instance = higher_potential_instances[0][0]
+                        else:
+                            instances_matching += 2
+                    if instances_matching == 1:
+                        # Mapping the nets of the block!
+                        maps_performed = 0
+                        # Updating the number of matching wires the first time
+                        if (reversed_instance.input_wires_matching_number == 0) and (
+                            reversed_instance.output_wires_matching_number == 0
+                        ):
+                            for reversed_wire in reversed_instance.input_wires_names:
+                                for impl_wire in saved_instance.input_wires_names:
+                                    if reversed_wire == impl_wire:
+                                        reversed_instance.input_wires_matching_number += (
+                                            1
+                                        )
+                            for reversed_wire in reversed_instance.output_wires_names:
+                                for impl_wire in saved_instance.output_wires_names:
+                                    if reversed_wire == impl_wire:
+                                        reversed_instance.output_wires_matching_number += (
+                                            1
+                                        )
+                            maps_performed += 1
+                        # Update the ummaped wire
+                        if (
+                            reversed_instance.input_wires_number
+                            - reversed_instance.input_wires_matching_number
+                        ) == 1:
+                            # Map Input Net
+                            # Find Input wire in the reversed_instance that is not found in the impl_instance
+                            reversed_input_index = 0
+                            reversed_input_found = False
+                            for i, reversed_wire in enumerate(
+                                reversed_instance.input_wires_names
+                            ):
+                                for impl_wire in saved_instance.input_wires_names:
+                                    if reversed_wire == impl_wire:
+                                        reversed_input_found = True
+                                if reversed_input_found == False:
+                                    reversed_input_index = i
+                                reversed_input_found = False
+                            # Find Input wire in the impl_instance that is not found in the reversed_instance
+                            impl_input_index = 0
+                            impl_input_found = False
+                            for i, impl_wire in enumerate(
+                                saved_instance.input_wires_names
+                            ):
+                                for (
+                                    reversed_wire
+                                ) in reversed_instance.input_wires_names:
+                                    if reversed_wire == impl_wire:
+                                        impl_input_found = True
+                                if impl_input_found == False:
+                                    impl_input_index = i
+                                impl_input_found = False
+                            # Map the net
+                            old_wire_name = reversed_instance.input_wires_names[
+                                reversed_input_index
+                            ]
+                            new_wire_name = saved_instance.input_wires_names[
+                                impl_input_index
+                            ]
+                            reversed_instance.input_wires_names[
+                                reversed_input_index
+                            ] = new_wire_name
+                            reversed_instance.input_wires_matching_number += 1
+                            # Loop through all the reversed blocks, and if they have inputs or
+                            # outputs equal to the old_wire_name change them to be the new_wire_name
+                            for reversed_block in reversed_netlist:
+                                for i, reversed_block_input_wire in enumerate(
+                                    reversed_block.input_wires_names
+                                ):
+                                    if reversed_block_input_wire == old_wire_name:
+                                        reversed_block.input_wires_names[
+                                            i
+                                        ] = new_wire_name
+                                for i, reversed_block_output_wire in enumerate(
+                                    reversed_block.output_wires_names
+                                ):
+                                    if reversed_block_output_wire == old_wire_name:
+                                        reversed_block.output_wires_names[
+                                            i
+                                        ] = new_wire_name
+                            maps_performed += 1
+                        if (
+                            reversed_instance.output_wires_number
+                            - reversed_instance.output_wires_matching_number
+                        ) == 1:
+                            # Map Output Net
+                            # This should work if all blocks in the netlist only have one output wire!
+                            for i, reversed_wire in enumerate(
+                                reversed_instance.output_wires_names
+                            ):
+                                for impl_wire in saved_instance.output_wires_names:
+                                    if reversed_wire != impl_wire:
+                                        reversed_instance.output_wires_names[
+                                            i
+                                        ] = impl_wire
+                                        reversed_instance.output_wires_matching_number += (
+                                            1
+                                        )
+                                        # Loop through all the reversed blocks, and if they have inputs
+                                        # equal to the reversed_wire change them to be the impl_wire
+                                        for reversed_block in reversed_netlist:
+                                            for (
+                                                i,
+                                                reversed_block_input_wire,
+                                            ) in enumerate(
+                                                reversed_block.input_wires_names
+                                            ):
+                                                if (
+                                                    reversed_block_input_wire
+                                                    == reversed_wire
+                                                ):
+                                                    reversed_block.input_wires_names[
+                                                        i
+                                                    ] = impl_wire
+                            maps_performed += 1
+                        if maps_performed > 0:
+                            mapped_blocks += 1
+                            progress = True
+                            mapped_pair_and_types = []
+                            mapped_pair_and_types.append(saved_instance.instance_name)
+                            mapped_pair_and_types.append(
+                                reversed_instance.instance_name
+                            )
+                            mapped_pair_and_types.append(saved_instance.instance_type)
+                            mapped_pair_and_types.append(
+                                reversed_instance.instance_type
+                            )
+                            mapped_points.append(mapped_pair_and_types)
+
+        # ################ Prints all mapped blocks ################
+        # print_mapped_blocks(mapped_points)
+
+        # ################ Print all mapped instances following conformal syntax ################
+        # generate_mapped_points_file(mapped_points, ir1.top_instance.reference.name, ir2.top_instance.reference.name)
+
+        # ################ Print the Mapped Points File to be used by Conformal ################
+        generate_conformal_mapped_points_file(
+            ir1.top_instance,
+            ir1.top_instance.reference.name,
+            ir2.top_instance.reference.name,
+        )
+
+        # Print Data After Mapping
+        # ################ Printing Data from Reversed netlist ################
+        # print_out("///////////////////////////////// reversed_netlist /////////////////////////////////")
+        # print_netlist(reversed_netlist)
+
+        # ################ Printing Data from Golden netlist ##################
+        # print_out("///////////////////////////////// golden_netlist /////////////////////////////////")
+        # print_netlist(golden_netlist)
+    except Exception as e:
+        raise e
+    finally:
+        if print_file != stdout:
+            print_file.close()
+
+
+if __name__ == "__main__":
     ################ Parsing command line arguments ################
     parser = argparse.ArgumentParser()
     parser.add_argument("golden_netlist")
     parser.add_argument("reversed_netlist")
     args = parser.parse_args()
-
-    ################ Fetching Data from Golden netlist ################
-    # Loads the first netlist as intermediate representation (ir1)
-    ir1 = sdn.parse(args.golden_netlist)
-    # Get the first library in the netlist
-    library1 = ir1.libraries[0]
-    golden_netlist = get_netlist(library1)
-
-    ################ Fetching Data from Reversed netlist ################
-    # Loads the second netlist as intermediate representation (ir2)
-    ir2 = sdn.parse(args.reversed_netlist)
-    # Get the first library in the netlist
-    library2 = ir2.libraries[0]
-    reversed_netlist = get_netlist(library2)
-
-    # Print Data Before Mapping
-    # ################ Printing Data from Golden netlist ##################
-    # print("golden_netlist")
-    # print_netlist(golden_netlist)
-
-    # ################ Printing Data from Reversed netlist ################
-    # print("reversed_netlist")
-    # print_netlist(reversed_netlist)
-
-    ########################## Mapping Algorithm ##########################
-    mapped_points = []
-    mapped_blocks = 0
-    progress = True
-    while (((len(reversed_netlist) - 2) != mapped_blocks) and (progress)): # - 2 for G and P (Which should stay unmapped for now)
-        progress = False
-        # Loop through reversed netlist blocks
-        for reversed_instance in reversed_netlist:
-            # If instance has unmatching wires
-            if ((reversed_instance.input_wires_number != reversed_instance.input_wires_matching_number) and 
-            (reversed_instance.output_wires_number != reversed_instance.output_wires_matching_number)):
-                potential_instances = []
-                higher_potential_instances = []
-                saved_instance = None
-                instances_matching = 0
-                # Loop through golden netlist blocks
-                for impl_instance in golden_netlist:
-                    # If instances have same # of wires as input, output, and other
-                    if ((reversed_instance.input_wires_number == impl_instance.input_wires_number) and
-                    (reversed_instance.output_wires_number == impl_instance.output_wires_number) and
-                    (reversed_instance.other_wires_number == impl_instance.other_wires_number)):
-                        # print(reversed_instance.instance_name + " vs " + impl_instance.instance_name)
-                        # Check for matching in inputs
-                        input_wires_matching = 0
-                        for reversed_wire in reversed_instance.input_wires_names:
-                            for impl_wire in impl_instance.input_wires_names:
-                                if (reversed_wire == impl_wire):
-                                    input_wires_matching += 1
-                        # Check for matching in outputs
-                        output_wires_matching = 0
-                        for reversed_wire in reversed_instance.output_wires_names:
-                            for impl_wire in impl_instance.output_wires_names:
-                                if (reversed_wire == impl_wire):
-                                    output_wires_matching += 1
-                        # If they match, add to potential_instances
-                        if ((input_wires_matching > 0) or (output_wires_matching > 0)):
-                            wires_matching = input_wires_matching + output_wires_matching
-                            potential_pair = [impl_instance, wires_matching]
-                            potential_instances.append(potential_pair)
-                # Check if it is only one, if not get the ones with highest number of matching wires
-                if (len(potential_instances) == 1):
-                    instances_matching += 1
-                    saved_instance = potential_instances[0][0]
-                elif (len(potential_instances) > 1):
-                    # Getting the max number of matching wires
-                    max_num = 0
-                    for i in range(len(potential_instances)):
-                        matching_wires = potential_instances[i][1]
-                        if (matching_wires > max_num):
-                            max_num = matching_wires
-                    # Getting the instances with the max number of matching wires
-                    for i in range(len(potential_instances)):
-                        matching_wires = potential_instances[i][1]
-                        if (matching_wires == max_num):
-                            higher_potential_instances.append(potential_instances[i])
-                    # If it is only one save the instance, if not prepare for no mapping!
-                    if (len(higher_potential_instances) == 1):
-                        instances_matching += 1
-                        saved_instance = higher_potential_instances[0][0] 
-                    else:
-                        instances_matching += 2
-                if (instances_matching == 1):  
-                    # Mapping the nets of the block!
-                    maps_performed = 0
-                    # Updating the number of matching wires the first time
-                    if ((reversed_instance.input_wires_matching_number == 0) and (reversed_instance.output_wires_matching_number == 0)):
-                        for reversed_wire in reversed_instance.input_wires_names:
-                                for impl_wire in saved_instance.input_wires_names:
-                                    if (reversed_wire == impl_wire):
-                                        reversed_instance.input_wires_matching_number += 1
-                        for reversed_wire in reversed_instance.output_wires_names:
-                                for impl_wire in saved_instance.output_wires_names:
-                                    if (reversed_wire == impl_wire):
-                                        reversed_instance.output_wires_matching_number += 1
-                        maps_performed += 1
-                    # Update the ummaped wire
-                    if ((reversed_instance.input_wires_number - reversed_instance.input_wires_matching_number) == 1):
-                        # Map Input Net
-                        # Find Input wire in the reversed_instance that is not found in the impl_instance
-                        reversed_input_index = 0
-                        reversed_input_found = False
-                        for i, reversed_wire in enumerate(reversed_instance.input_wires_names):
-                            for impl_wire in saved_instance.input_wires_names:
-                                if (reversed_wire == impl_wire):
-                                    reversed_input_found = True
-                            if (reversed_input_found == False):
-                                reversed_input_index = i
-                            reversed_input_found = False
-                        # Find Input wire in the impl_instance that is not found in the reversed_instance
-                        impl_input_index = 0
-                        impl_input_found = False
-                        for i, impl_wire in enumerate(saved_instance.input_wires_names):
-                            for reversed_wire in reversed_instance.input_wires_names:
-                                if (reversed_wire == impl_wire):
-                                    impl_input_found = True
-                            if (impl_input_found == False):
-                                impl_input_index = i
-                            impl_input_found = False   
-                        # Map the net
-                        old_wire_name = reversed_instance.input_wires_names[reversed_input_index]
-                        new_wire_name = saved_instance.input_wires_names[impl_input_index]
-                        reversed_instance.input_wires_names[reversed_input_index] = new_wire_name
-                        reversed_instance.input_wires_matching_number += 1
-                        # Loop through all the reversed blocks, and if they have inputs or
-                        # outputs equal to the old_wire_name change them to be the new_wire_name
-                        for reversed_block in reversed_netlist:
-                            for i, reversed_block_input_wire in enumerate(reversed_block.input_wires_names):
-                                if (reversed_block_input_wire == old_wire_name):
-                                    reversed_block.input_wires_names[i] = new_wire_name
-                            for i, reversed_block_output_wire in enumerate(reversed_block.output_wires_names):
-                                if (reversed_block_output_wire == old_wire_name):
-                                    reversed_block.output_wires_names[i] = new_wire_name
-                        maps_performed += 1
-                    if ((reversed_instance.output_wires_number - reversed_instance.output_wires_matching_number) == 1):
-                        # Map Output Net
-                        # This should work if all blocks in the netlist only have one output wire!
-                        for i, reversed_wire in enumerate(reversed_instance.output_wires_names):
-                            for impl_wire in saved_instance.output_wires_names:
-                                if (reversed_wire != impl_wire):
-                                    reversed_instance.output_wires_names[i] = impl_wire
-                                    reversed_instance.output_wires_matching_number += 1
-                                    # Loop through all the reversed blocks, and if they have inputs
-                                    # equal to the reversed_wire change them to be the impl_wire
-                                    for reversed_block in reversed_netlist:
-                                        for i, reversed_block_input_wire in enumerate(reversed_block.input_wires_names):
-                                            if (reversed_block_input_wire == reversed_wire):
-                                                reversed_block.input_wires_names[i] = impl_wire
-                        maps_performed += 1
-                    if (maps_performed > 0):
-                        mapped_blocks += 1
-                        progress = True
-                        mapped_pair_and_types = []
-                        mapped_pair_and_types.append(saved_instance.instance_name)
-                        mapped_pair_and_types.append(reversed_instance.instance_name)
-                        mapped_pair_and_types.append(saved_instance.instance_type)
-                        mapped_pair_and_types.append(reversed_instance.instance_type)
-                        mapped_points.append(mapped_pair_and_types)
-
-    # ################ Prints all mapped blocks ################
-    #print_mapped_blocks(mapped_points)
-
-    # ################ Print all mapped instances following conformal syntax ################
-    #generate_mapped_points_file(mapped_points, ir1.top_instance.reference.name, ir2.top_instance.reference.name)
-
-    # ################ Print the Mapped Points File to be used by Conformal ################
-    generate_conformal_mapped_points_file(ir1.top_instance, ir1.top_instance.reference.name, ir2.top_instance.reference.name)
-
-    # Print Data After Mapping
-    # ################ Printing Data from Reversed netlist ################
-    # print("///////////////////////////////// reversed_netlist /////////////////////////////////")
-    # print_netlist(reversed_netlist)
-
-    # ################ Printing Data from Golden netlist ##################
-    # print("///////////////////////////////// golden_netlist /////////////////////////////////")
-    # print_netlist(golden_netlist)
-
-if __name__ == "__main__":
-    main()
+    main(args.golden_netlist, args.reversed_netlist)

--- a/scripts/bfasst/opt/base.py
+++ b/scripts/bfasst/opt/base.py
@@ -6,8 +6,8 @@ from bfasst.status import Status
 
 
 class OptTool(Tool):
-    def __init__(self, cwd) -> None:
-        super().__init__(cwd)
+    def __init__(self, cwd, flow_args="") -> None:
+        super().__init__(cwd, flow_args)
         self.success_status = Status(OptStatus.SUCCESS)
 
     # This method should run an optimizer.  It should return

--- a/scripts/bfasst/opt/ic2_lse.py
+++ b/scripts/bfasst/opt/ic2_lse.py
@@ -7,7 +7,7 @@ import in_place
 
 import bfasst
 from bfasst.opt.base import OptTool
-from bfasst.status import Status, OptStatus
+from bfasst.status import BfasstException, Status, OptStatus
 from bfasst.utils import error
 
 PROJECT_TEMPLATE_FILE = "template_lse.prj"
@@ -56,19 +56,16 @@ class IC2_LSE_OptTool(OptTool):
             prj_path = self.create_ic2_lse_project_file(design, edif_path_temp, in_files, lib_files)
 
             # Run Icecube 2 LSE synthesis
-            status = self.run_sythesis(prj_path, log_path)
-            if status.error:
+            try:
+                status = self.run_sythesis(prj_path, log_path)
+            except BfasstException as e:
                 # If generic error, see if log has something more specific
-                if status.status == OptStatus.ERROR:
+                if e.status == OptStatus.ERROR:
                     new_status = self.check_opt_log(log_path)
-                    if new_status.error:
-                        return new_status
-                return status
+                raise e
 
         # Parse synthesis log for errors
         status = self.check_opt_log(log_path)
-        if status.error:
-            return status
 
         if need_to_run:
             # Copy edif netlist out of project directory3

--- a/scripts/bfasst/opt/ic2_synplify.py
+++ b/scripts/bfasst/opt/ic2_synplify.py
@@ -6,7 +6,7 @@ import os.path
 
 import bfasst
 from bfasst.opt.base import OptTool
-from bfasst.status import Status, OptStatus
+from bfasst.status import BfasstException, Status, OptStatus
 
 PROJECT_TEMPLATE_FILE = "template_sp.prj"
 IC2_SYNPLIFY_PROJ_FILE = "synplify_project.prj"
@@ -56,19 +56,16 @@ class IC2_Synplify_OptTool(OptTool):
             )
 
             # Run Icecube 2 LSE synthesis
-            status = self.run_sythesis(prj_path, log_path)
-            if status.error:
+            try:
+                status = self.run_sythesis(prj_path, log_path)
+            except BfasstException as e:
                 # If generic error, see if log has something more specific
-                if status.status == OptStatus.ERROR:
+                if e.status == OptStatus.ERROR:
                     new_status = self.check_opt_log(log_path)
-                    if new_status.error:
-                        return new_status
-                return status
+                raise e
 
         # Parse synthesis log for errors
         status = self.check_opt_log(log_path)
-        if status.error:
-            return status
 
         if need_to_run:
             # Copy edif netlist out of project directory3

--- a/scripts/bfasst/output_cntrl.py
+++ b/scripts/bfasst/output_cntrl.py
@@ -1,0 +1,95 @@
+import sys
+import threading
+from io import StringIO
+from werkzeug import local
+
+# Save all of the objects for use later.
+orig___stdout__ = sys.__stdout__
+orig___stderr__ = sys.__stderr__
+orig_stdout = sys.stdout
+orig_stderr = sys.stderr
+thread_proxies = {}
+
+
+def redirect():
+    """
+    Enables the redirect for the current thread's output to a single cStringIO
+    object and returns the object.
+
+    :return: The StringIO object.
+    :rtype: ``io.StringIO``
+    """
+    # Get the current thread's identity.
+    ident = threading.current_thread().ident
+
+    # Enable the redirect and return the cStringIO object.
+    thread_proxies[ident] = StringIO()
+    return thread_proxies[ident]
+
+
+def cleanup_redirect():
+    """
+    Disables the redirect for the current thread's output to a single cStringIO
+    object and returns the object.
+
+    :return: The final string value.
+    :rtype: ``str``
+    """
+    # Get the current thread's identity.
+    ident = threading.current_thread().ident
+
+    # Only act on proxied threads.
+    if ident not in thread_proxies:
+        return
+
+    thread_proxies[ident].close()
+    del thread_proxies[ident]
+
+
+def _get_stream(original):
+    """
+    Returns the inner function for use in the LocalProxy object.
+
+    :param original: The stream to be returned if thread is not proxied.
+    :type original: ``file``
+    :return: The inner function for use in the LocalProxy object.
+    :rtype: ``function``
+    """
+    def proxy():
+        """
+        Returns the original stream if the current thread is not proxied,
+        otherwise we return the proxied item.
+
+        :return: The stream object for the current thread.
+        :rtype: ``file``
+        """
+        # Get the current thread's identity.
+        ident = threading.current_thread().ident
+
+        # Return the proxy, otherwise return the original.
+        return thread_proxies.get(ident, original)
+
+    # Return the inner function.
+    return proxy
+
+
+def enable_proxy():
+    """
+    Overwrites __stdout__, __stderr__, stdout, and stderr with the proxied
+    objects.
+    """
+    sys.__stdout__ = local.LocalProxy(_get_stream(sys.__stdout__))
+    # sys.__stderr__ = local.LocalProxy(_get_stream(sys.__stderr__))
+    sys.stdout = local.LocalProxy(_get_stream(sys.stdout))
+    # sys.stderr = local.LocalProxy(_get_stream(sys.stderr))
+
+
+def disable_proxy():
+    """
+    Overwrites __stdout__, __stderr__, stdout, and stderr with the original
+    objects.
+    """
+    sys.__stdout__ = orig___stdout__
+    # sys.__stderr__ = orig___stderr__
+    sys.stdout = orig_stdout
+    # sys.stderr = orig_stderr

--- a/scripts/bfasst/reverse_bit/base.py
+++ b/scripts/bfasst/reverse_bit/base.py
@@ -6,8 +6,8 @@ from bfasst.status import Status, BitReverseStatus
 
 
 class ReverseBitTool(Tool):
-    def __init__(self, cwd) -> None:
-        super().__init__(cwd)
+    def __init__(self, cwd, flow_args="") -> None:
+        super().__init__(cwd, flow_args)
         self.success_status = Status(BitReverseStatus.SUCCESS)
 
     # This method should run bitstream reversal.  It should return

--- a/scripts/bfasst/reverse_bit/icestorm.py
+++ b/scripts/bfasst/reverse_bit/icestorm.py
@@ -42,15 +42,11 @@ class Icestorm_ReverseBitTool(ReverseBitTool):
             # Bitstream to ascii file
             asc_path = self.work_dir / (design.top + ".asc")
             status = self.convert_bit_to_asc(design.bitstream_path, asc_path)
-            if status.error:
-                return status
 
             # Ascii to netlist
             status = self.convert_asc_to_netlist(
                 asc_path, design.constraints_path, design.reversed_netlist_path
             )
-            if status.error:
-                return status
 
         self.write_to_results_file(design, design.reversed_netlist_path, need_to_run)
 

--- a/scripts/bfasst/reverse_bit/xray.py
+++ b/scripts/bfasst/reverse_bit/xray.py
@@ -31,9 +31,7 @@ class XRay_ReverseBitTool(ReverseBitTool):
         self.xray_db_path = self.fasm2bels_path / "third_party" / "prjxray-db"
         self.db_root = self.xray_db_path / config.PART_FAMILY
 
-    def reverse_bitstream(self, design, print_to_stdout=True):
-        self.print_to_stdout = print_to_stdout
-
+    def reverse_bitstream(self, design):
         # To fasm process
         fasm_path = self.work_dir / (design.top + ".fasm")
         generate_fasm = ToolProduct(fasm_path)
@@ -59,12 +57,10 @@ class XRay_ReverseBitTool(ReverseBitTool):
         )
 
         if status is not None:
-            if self.print_to_stdout:
-                self.print_skipping_reverse_bit()
+            self.print_skipping_reverse_bit()
             return status
 
-        if self.print_to_stdout:
-            self.print_running_reverse_bit()
+        self.print_running_reverse_bit()
 
         # Bitstream to fasm file
         status = self.convert_bit_to_fasm(design.bitstream_path, fasm_path)
@@ -130,9 +126,7 @@ class XRay_ReverseBitTool(ReverseBitTool):
             constraints_path,
         ]
 
-        if self.print_to_stdout:
-            # Print the command that is run
-            print(" ".join((str(s) for s in cmd)))
+        print(" ".join((str(s) for s in cmd)))
 
         with open(self.to_netlist_log, "w") as fp:
             proc = subprocess.Popen(
@@ -143,9 +137,8 @@ class XRay_ReverseBitTool(ReverseBitTool):
                 universal_newlines=True,
             )
             for line in proc.stdout:
-                if self.print_to_stdout:
-                    sys.stdout.write(line)
-                    sys.stdout.flush()
+                sys.stdout.write(line)
+                sys.stdout.flush()
                 fp.write(line)
                 fp.flush()
             proc.communicate()

--- a/scripts/bfasst/status.py
+++ b/scripts/bfasst/status.py
@@ -79,7 +79,9 @@ msg_map = {
 }
 
 class BfasstException(Exception):
-    pass
+    def __init__(self, err, msg):
+        super().__init__(msg)
+        self.error = err
 
 
 class Status:
@@ -87,7 +89,7 @@ class Status:
         self.status = status
         self.msg = msg
         if status.value:
-            raise BfasstException(f"{msg_map[status]} ({msg})")
+            raise BfasstException(status, f"{msg_map[status]} ({msg})")
 
     def __str__(self):
         s = msg_map[self.status]

--- a/scripts/bfasst/status.py
+++ b/scripts/bfasst/status.py
@@ -85,14 +85,11 @@ class BfasstException(Exception):
 
 
 class Status:
-    def __init__(self, status, msg=None):
+    def __init__(self, status, msg="", raise_excep=True):
         self.status = status
-        self.msg = msg
-        if status.value:
-            raise BfasstException(status, f"{msg_map[status]} ({msg})")
+        self.msg = f" ({msg})" if msg else ""
+        if status.value and raise_excep:
+            raise BfasstException(status, f"{msg_map[status]}{self.msg}")
 
     def __str__(self):
-        s = msg_map[self.status]
-        if self.msg is not None:
-            s = f"{s} ({self.msg})"
-        return s
+        return f"{msg_map[self.status]}{self.msg}"

--- a/scripts/bfasst/status.py
+++ b/scripts/bfasst/status.py
@@ -71,6 +71,11 @@ msg_map = {
     CompareStatus.TIMEOUT: "!! Compare timeout",
     CompareStatus.PARSE_PROBLEM: "!! Parse error",
     CompareStatus.NEED_TO_RUN_ONESPIN: "Exported to Onespin",
+    ErrorInjectionStatus.SUCCESS : "Error Injection Successful",
+    ErrorInjectionStatus.ERROR : "Error Injection Unsuccessful",
+    ErrorInjectionStatus.NO_YAML : "No YAML for Error Injection",
+    ErrorInjectionStatus.FCN_SUCCESS : "FCN Successful",
+    ErrorInjectionStatus.FCN_ERROR : "FCN Error",    
 }
 
 class BfasstException(Exception):

--- a/scripts/bfasst/status.py
+++ b/scripts/bfasst/status.py
@@ -73,19 +73,19 @@ msg_map = {
     CompareStatus.NEED_TO_RUN_ONESPIN: "Exported to Onespin",
 }
 
+class BfasstException(Exception):
+    pass
+
 
 class Status:
     def __init__(self, status, msg=None):
-        self.error = False
-
         self.status = status
-        if status.value:
-            self.error = True
-
         self.msg = msg
+        if status.value:
+            raise BfasstException(f"{msg_map[status]} ({msg})")
 
     def __str__(self):
         s = msg_map[self.status]
         if self.msg is not None:
-            s += " (" + self.msg + ")"
+            s = f"{s} ({self.msg})"
         return s

--- a/scripts/bfasst/status.py
+++ b/scripts/bfasst/status.py
@@ -88,6 +88,7 @@ class Status:
     def __init__(self, status, msg="", raise_excep=True):
         self.status = status
         self.msg = f" ({msg})" if msg else ""
+        self.error = True if status.value else False
         if status.value and raise_excep:
             raise BfasstException(status, f"{msg_map[status]}{self.msg}")
 

--- a/scripts/bfasst/synth/base.py
+++ b/scripts/bfasst/synth/base.py
@@ -6,8 +6,8 @@ from bfasst.status import SynthStatus, Status
 
 
 class SynthesisTool(tool.Tool):
-    def __init__(self, cwd) -> None:
-        super().__init__(cwd)
+    def __init__(self, cwd, flow_args="") -> None:
+        super().__init__(cwd, flow_args)
         self.success_status = Status(SynthStatus.SUCCESS)
 
     # This method should run synthesis.  It should return

--- a/scripts/bfasst/synth/vivado.py
+++ b/scripts/bfasst/synth/vivado.py
@@ -15,8 +15,7 @@ from bfasst.tool import ToolProduct
 class Vivado_SynthesisTool(SynthesisTool):
     TOOL_WORK_DIR = "vivado_synth"
 
-    def create_netlist(self, design, print_to_stdout=True):
-        self.print_to_stdout = print_to_stdout
+    def create_netlist(self, design):
         log_path = self.work_dir / bfasst.config.SYNTH_LOG_NAME
 
         # Save edif netlist path to design object
@@ -35,13 +34,11 @@ class Vivado_SynthesisTool(SynthesisTool):
         )
 
         if status is not None:
-            if self.print_to_stdout:
-                self.print_skipping_synth()
+            self.print_skipping_synth()
             return status
 
         # Run synthesis flow
-        if self.print_to_stdout:
-            self.print_running_synth()
+        self.print_running_synth()
 
         report_io_path = self.work_dir / "report_io.txt"
 
@@ -118,8 +115,7 @@ class Vivado_SynthesisTool(SynthesisTool):
                 universal_newlines=True,
             )
             for line in proc.stdout:
-                if self.print_to_stdout:
-                    sys.stdout.write(line)
+                sys.stdout.write(line)
                 fp.write(line)
                 fp.flush()
                 # if re.match("\s*ERROR:", line):

--- a/scripts/bfasst/synth/vivado.py
+++ b/scripts/bfasst/synth/vivado.py
@@ -96,11 +96,11 @@ class Vivado_SynthesisTool(SynthesisTool):
 
                 if not self.flow_args:
                 # Synthesize - do not include any DSP modules in the synthesized design
-                    fp.write(f"synth_design -top " + design.top + " -max_dsp 0" + "\n")
+                    fp.write(f"synth_design -top {design.top} -max_dsp 0\n")
                 else:
                     top = f" -top {design.top} " if "top" not in self.flow_args else ""
-                    dsp = " -max_dsp 0 " if "max_dsp" not in self.flow_args else ""
-                    fp.write(f"synth_design{top}{dsp} {self.flow_args}")
+                    dsp = " -max_dsp 0" if "max_dsp" not in self.flow_args else ""
+                    fp.write(f"synth_design{top}{dsp} {self.flow_args}\n")
 
                 if "out_of_context" not in self.flow_args:
                     # Auto-place ports

--- a/scripts/bfasst/tool.py
+++ b/scripts/bfasst/tool.py
@@ -16,10 +16,10 @@ class ToolProduct:
 class Tool(abc.ABC):
     TERM_COLOR_STAGE = TermColor.PURPLE
 
-    def __init__(self, cwd):
+    def __init__(self, cwd, flow_args = ""):
         super().__init__()
         self.cwd = cwd
-
+        self.flow_args = flow_args
         self.work_dir = self.make_work_dir()
 
     @property

--- a/scripts/bfasst/tool.py
+++ b/scripts/bfasst/tool.py
@@ -53,11 +53,9 @@ class Tool(abc.ABC):
 
                 # If log file has an error, return that status
                 status = tool_product.check_log_fcn(tool_product.log_path)
-                if status.error:
-                    return status
 
                 # If log file doesn't have an error, but output file is expected and missing, re-run
-                elif (tool_product.file_path is not None) and (not tool_product.file_path.is_file()):
+                if (tool_product.file_path is not None) and (not tool_product.file_path.is_file()):
                     return None
             else:
                 # This ToolProduct doesn't produce a log file

--- a/scripts/run_design.py
+++ b/scripts/run_design.py
@@ -1,15 +1,55 @@
 #!/usr/bin/python3
+from argparse import ArgumentParser, Action
+from pathlib import Path
+import sys
 
-import argparse
-import glob
-import pathlib
-
-import bfasst
-from bfasst import paths, flows
+from bfasst.design import Design
+from bfasst import paths
+from bfasst.flows import Flows, run_flow, FlowArgs
 
 
-def main():
-    parser = argparse.ArgumentParser()
+def main(design_path, flow, error_flow, flow_args):
+    # Load the design
+    design = Design(design_path)
+
+    # Create temp folder
+    build_dir = (
+        Path.cwd() / "build" / flow / (design_path.relative_to(paths.EXAMPLES_PATH))
+    )
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    # Store the error flow for later
+    if error_flow:
+        design.error_flow_yaml = error_flow + ".yaml"
+
+    # Get the flow object
+    flow = Flows(flow)
+
+    # Run the design
+    status = run_flow(design, flow, flow_args, build_dir)
+
+    print(status)
+
+
+class SetFlowArgs(Action):
+    """
+    Make argparse automatically set flow_args dictionary variables.
+    """
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+        super().__init__(option_strings, dest, **kwargs)
+    def __call__(self, parser, namespace, values, option_string=None):
+        key = FlowArgs[option_string[2:].upper()]
+        getattr(namespace, self.dest)[key] = values
+
+class Args:
+    def __init__(self):
+        # Set default values for flow_args here
+        self.flow_args = {k: "" for k in FlowArgs}
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
 
     # designs = []
     # for directory in bfasst.EXAMPLES_PATH.rglob("*"):
@@ -17,9 +57,21 @@ def main():
     #         designs.append(str(directory.relative_to(bfasst.EXAMPLES_PATH)))
 
     parser.add_argument("design_path", help="Path to design in examples directory.")
-    parser.add_argument("flow", choices=[e.value for e in flows.Flows])
-    parser.add_argument("flow_args", help="Arguments to be used in the flow for synthesis, implementation, mapping and equivalence checking")
+    parser.add_argument("flow", choices=[e.value for e in Flows])
+    parser.add_argument("--synth", help="Arguments for synthesis", 
+                        action=SetFlowArgs, dest="flow_args")
+    parser.add_argument("--impl", help="Arguments for implementation", 
+                        action=SetFlowArgs, dest="flow_args")
+    parser.add_argument("--map", help="Arguments for mapping", 
+                        action=SetFlowArgs, dest="flow_args")
+    parser.add_argument("--equiv", help="Arguments for equivalence", 
+                        action=SetFlowArgs, dest="flow_args")
+    parser.add_argument("--cmp", help="Arguments for comparison", 
+                        action=SetFlowArgs, dest="flow_args")
+    parser.add_argument("--err", help="Arguements for error flow", 
+                        action=SetFlowArgs, dest="flow_args")    
     parser.add_argument("--quiet", action="store_true")
+
     error_flows = []
     for dir_item in paths.ERROR_FLOW_PATH.iterdir():
         if (paths.EXPERIMENTS_PATH / dir_item).is_file() and dir_item.suffix == ".yaml":
@@ -29,38 +81,12 @@ def main():
         choices=error_flows,
         help="YAML file describing errors to inject for testing. Only works with flows designed for error injection",
     )
-    args = parser.parse_args()
+    args = Args()
+    parser.parse_args(namespace=args)
 
-    design_path = pathlib.Path(args.design_path)
+    design_path = Path(args.design_path)
     if not design_path.is_dir() and (paths.EXAMPLES_PATH / design_path).is_dir():
         design_path = paths.EXAMPLES_PATH / design_path
     design_path = design_path.absolute()
-
-    # Load the design
-    design = bfasst.design.Design(design_path)
-
-    # Create temp folder
-    build_dir = (
-        pathlib.Path.cwd() / "build" / args.flow / (design_path.relative_to(paths.EXAMPLES_PATH))
-    )
-    build_dir.mkdir(parents=True, exist_ok=True)
-
-    # Store the error flow for later
-    if args.error_flow:
-        design.error_flow_yaml = args.error_flow + ".yaml"
-
-    # Get the flow object
-    flow = flows.Flows(args.flow)
-
-    # Get the flow arguments
-    flow_args = args.flow_args
-
-    # Run the design
-    # status = bfasst.flow.run_flow(design, bfasst.flow.Flows.IC2_LSE_CONFORMAL, build_dir)
-    status = flows.run_flow(design, flow, flow_args, build_dir, print_to_stdout=not args.quiet)
-
-    print(status)
-
-
-if __name__ == "__main__":
-    main()
+    
+    main(design_path, args.flow, args.error_flow, args.flow_args)

--- a/scripts/run_design.py
+++ b/scripts/run_design.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 from argparse import ArgumentParser, Action
 from pathlib import Path
-import sys
 
 from bfasst.design import Design
 from bfasst import paths

--- a/scripts/run_design.py
+++ b/scripts/run_design.py
@@ -18,7 +18,7 @@ def main():
 
     parser.add_argument("design_path", help="Path to design in examples directory.")
     parser.add_argument("flow", choices=[e.value for e in flows.Flows])
-    parser.add_argument("-m", dest="mapping", default="conformal", help="Netlist mapping algorithm to be used for equivalence checking.")
+    parser.add_argument("flow_args", help="Arguments to be used in the flow for synthesis, implementation, mapping and equivalence checking")
     parser.add_argument("--quiet", action="store_true")
     error_flows = []
     for dir_item in paths.ERROR_FLOW_PATH.iterdir():
@@ -52,12 +52,12 @@ def main():
     # Get the flow object
     flow = flows.Flows(args.flow)
 
-    # Get the mapping algorithm
-    mapping = args.mapping
+    # Get the flow arguments
+    flow_args = args.flow_args
 
     # Run the design
     # status = bfasst.flow.run_flow(design, bfasst.flow.Flows.IC2_LSE_CONFORMAL, build_dir)
-    status = flows.run_flow(design, flow, mapping, build_dir, print_to_stdout=not args.quiet)
+    status = flows.run_flow(design, flow, flow_args, build_dir, print_to_stdout=not args.quiet)
 
     print(status)
 

--- a/scripts/run_design.py
+++ b/scripts/run_design.py
@@ -18,6 +18,7 @@ def main():
 
     parser.add_argument("design_path", help="Path to design in examples directory.")
     parser.add_argument("flow", choices=[e.value for e in flows.Flows])
+    parser.add_argument("-m", dest="mapping", default="conformal", help="Netlist mapping algorithm to be used for equivalence checking.")
     parser.add_argument("--quiet", action="store_true")
     error_flows = []
     for dir_item in paths.ERROR_FLOW_PATH.iterdir():
@@ -51,9 +52,12 @@ def main():
     # Get the flow object
     flow = flows.Flows(args.flow)
 
+    # Get the mapping algorithm
+    mapping = args.mapping
+
     # Run the design
     # status = bfasst.flow.run_flow(design, bfasst.flow.Flows.IC2_LSE_CONFORMAL, build_dir)
-    status = flows.run_flow(design, flow, build_dir, print_to_stdout=not args.quiet)
+    status = flows.run_flow(design, flow, mapping, build_dir, print_to_stdout=not args.quiet)
 
     print(status)
 

--- a/scripts/run_design.py
+++ b/scripts/run_design.py
@@ -63,8 +63,6 @@ if __name__ == "__main__":
                         action=SetFlowArgs, dest="flow_args")
     parser.add_argument("--map", help="Arguments for mapping", 
                         action=SetFlowArgs, dest="flow_args")
-    parser.add_argument("--equiv", help="Arguments for equivalence", 
-                        action=SetFlowArgs, dest="flow_args")
     parser.add_argument("--cmp", help="Arguments for comparison", 
                         action=SetFlowArgs, dest="flow_args")
     parser.add_argument("--err", help="Arguements for error flow", 

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -2,13 +2,12 @@
 
 import argparse
 import datetime
-from io import StringIO
 import multiprocessing
 import pathlib
+from shutil import copyfileobj
 import sys
 import threading
 import time
-from werkzeug import local
 
 
 import bfasst
@@ -24,7 +23,7 @@ print_lock = None
 
 
 def print_running_list():
-    """ This function prints the list of jobs that are currently executing, and how long they have been running for """
+    """This function prints the list of jobs that are currently executing, and how long they have been running for"""
 
     global running_list
     global print_lock
@@ -44,7 +43,7 @@ def print_running_list():
 
 
 def update_runtimes_thread(num_jobs):
-    """ This function, designed to run in its own thread, calls print_running_list() periodically, until all jobs are done, or it is terminated. """
+    """This function, designed to run in its own thread, calls print_running_list() periodically, until all jobs are done, or it is terminated."""
 
     inverval_seconds = 1.0
 
@@ -64,7 +63,7 @@ def update_runtimes_thread(num_jobs):
 
 
 def run_design(design, design_dir, flow_fcn, flow_args):
-    """ This function runs a single job, running the selected CAD flow for one design """
+    """This function runs a single job, running the selected CAD flow for one design"""
 
     global running_list
 
@@ -80,13 +79,15 @@ def run_design(design, design_dir, flow_fcn, flow_args):
         status = Status(status=e.error, msg=str(e), raise_excep=False)
     finally:
         with open(f"{design_dir / design.path.name}.log", "w") as f:
-            f.write(buf.getvalue())
+            buf.seek(0)
+            copyfileobj(buf, f)
+            # f.write(buf.getvalue())
         cleanup_redirect()
     return (design, status)
 
 
 def on_error(e, pool, update_process):
-    """ This should be called when a job process raises an exception.  This shuts down all jobs in the pool, as well as the update_process. """
+    """This should be called when a job process raises an exception.  This shuts down all jobs in the pool, as well as the update_process."""
     pool.terminate()
     if update_process is not None:
         update_process.terminate()
@@ -94,7 +95,7 @@ def on_error(e, pool, update_process):
 
 
 def job_done(retval):
-    """ Callback on job completion.  Removes job from the running_list, prints the job completion status, and saves the return status."""
+    """Callback on job completion.  Removes job from the running_list, prints the job completion status, and saves the return status."""
     global running_list
     global print_lock
 
@@ -124,11 +125,13 @@ def main():
     global print_lock
 
     parser = argparse.ArgumentParser()
-    enable_proxy() # Enable STDOUT redirects
+    enable_proxy()  # Enable STDOUT redirects
 
     # Set up command line arguments
     parser.add_argument("experiment_yaml", help="Experiment yaml file.")
-    parser.add_argument("-j", "--threads", type=int, default=1, help="Number of threads")
+    parser.add_argument(
+        "-j", "--threads", type=int, default=1, help="Number of threads"
+    )
     args = parser.parse_args()
 
     experiment_yaml_path = pathlib.Path(args.experiment_yaml)
@@ -156,7 +159,9 @@ def main():
         # Create a per-design build directory
         design_dir = build_dir / design.rel_path
         design_dir.mkdir(parents=True, exist_ok=True)
-        designs_to_run.append((design, design_dir, experiment.flow_fcn, experiment.flow_args))
+        designs_to_run.append(
+            (design, design_dir, experiment.flow_fcn, experiment.flow_args)
+        )
 
     manager = multiprocessing.Manager()
     statuses = manager.list()
@@ -211,19 +216,43 @@ def main():
     j = 30
     print(
         "Synth Error:".ljust(j),
-        len([s for s in statuses if type(s.status) == bfasst.status.SynthStatus and s.error]),
+        len(
+            [
+                s
+                for s in statuses
+                if type(s.status) == bfasst.status.SynthStatus and s.error
+            ]
+        ),
     )
     print(
         "Opt Error:".ljust(j),
-        len([s for s in statuses if type(s.status) == bfasst.status.OptStatus and s.error]),
+        len(
+            [
+                s
+                for s in statuses
+                if type(s.status) == bfasst.status.OptStatus and s.error
+            ]
+        ),
     )
     print(
         "Impl Error:".ljust(j),
-        len([s for s in statuses if type(s.status) == bfasst.status.ImplStatus and s.error]),
+        len(
+            [
+                s
+                for s in statuses
+                if type(s.status) == bfasst.status.ImplStatus and s.error
+            ]
+        ),
     )
     print(
         "Bit Reverse Error:".ljust(j),
-        len([s for s in statuses if type(s.status) == bfasst.status.BitReverseStatus and s.error]),
+        len(
+            [
+                s
+                for s in statuses
+                if type(s.status) == bfasst.status.BitReverseStatus and s.error
+            ]
+        ),
     )
     print(
         "Compare Error:".ljust(j),
@@ -239,7 +268,13 @@ def main():
     )
     print(
         "Compare Not Equivalent:".ljust(j),
-        len([s for s in statuses if s.status == bfasst.status.CompareStatus.NOT_EQUIVALENT]),
+        len(
+            [
+                s
+                for s in statuses
+                if s.status == bfasst.status.CompareStatus.NOT_EQUIVALENT
+            ]
+        ),
     )
     print(
         "Compare Equivalent:".ljust(j),
@@ -249,7 +284,7 @@ def main():
     # print(types)
 
     print("-" * 80)
-    print("Execution took", round(t_end - t_start,1), "seconds")
+    print("Execution took", round(t_end - t_start, 1), "seconds")
 
 
 if __name__ == "__main__":

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -2,18 +2,15 @@
 
 import argparse
 import pathlib
-import queue
 import sys
 import time
 import multiprocessing
 import threading
-from threading import Thread
-import random
 import datetime
-import os
 
 
 import bfasst
+from bfasst.status import BfasstException, Status
 from bfasst.utils import TermColor, print_color
 
 # Globals
@@ -73,7 +70,10 @@ def run_design(design, design_dir, flow_fcn):
 
     # time.sleep(random.randint(1,2))
     # status = None
-    status = flow_fcn(design, design_dir, print_to_stdout=False)
+    try:
+        status = flow_fcn(design, design_dir, print_to_stdout=False)
+    except BfasstException as e:
+        status = Status(status=e.error, msg=str(e), raise_excep=False)
     return (design, status)
 
 

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -71,7 +71,7 @@ def run_design(design, design_dir, flow_fcn):
     # time.sleep(random.randint(1,2))
     # status = None
     try:
-        status = flow_fcn(design, design_dir, print_to_stdout=False)
+        status = flow_fcn(design, design_dir)
     except BfasstException as e:
         status = Status(status=e.error, msg=str(e), raise_excep=False)
     return (design, status)


### PR DESCRIPTION
This pull request adds the following features:
- Error status triggers an exception. However, there is a parameter in the status constructor to prevent the exception from being raised. Checking for error status is now done in a try-catch block if you do not want the function to fail/return. 
- The framework for flow arguments is implemented. Xilinx flow arguments are supported for synthesis (SYNTH), including overwriting the default arguments for -dsp and -top. Xilinx implementation has been edited to work with designs synthesized out of context (constraints are not loaded and bitstream generation is skipped). CMP supports the argument "xilinx" or "lattice" (not case sensitive). This is directly fed into the VENDOR parameter when applicable.
    *Flow arguments include SYNTH, IMPL, MAP, EQUIV, CMP, & ERR
- Flow args are parsed into a dictionary with keys being the args and a string being the value. Currently for xilinx synthesis the entire SYNTH string is appended to the synth_design command. The flow args incorporate the new usage:
```
--synth FLOW_ARGS     Arguments for synthesis
--impl FLOW_ARGS      Arguments for implementation
--map FLOW_ARGS       Arguments for mapping
--equiv FLOW_ARGS     Arguments for equivalence
--cmp FLOW_ARGS       Arguments for comparison
--err FLOW_ARGS       Arguements for error flow
```
An example for xilinx flow would be:
```
run_design.py design_dir xilinx --synth "-mode out_of_context -flatten_hierarchy"
```
Or in the experiment .yaml file include:
```
synth: "-mode out_of_context -flatten_hierarchy"
```
- The flows.py file has been updated to include wrapper functions for each flow piece, ie: xilinx synthesis, yosys synthesis, yosys compare, etc. The flow functions now reference these wrappers. All flow functions accept a flow_args argument and all wrapper functions also accept the argument. The tool constructor also includes an optional flow_args parameter.
- Flow arguments can be specified in experiment .yaml files. They are not case-sensitive.
- run_experiment.py prints the output of each thread to build_dir/experiment_name/design/design_name.log
    *The running job and job completion status is still printed to stdout
    *References to print_to_stdout have been removed.
- run_experiment still only crashes when a Python Exception is raised and is not effected by the BfasstException (Status exceptions).

I have added a new .yaml "xilinx_ooc.yaml" which I used to test these new features. The command I used is
```
python scripts/run_experiment.py experiments/xilinx_ooc.yaml -j 8
```
