### PR TITLE
Fix to Issue#92

### DIFF
--- a/scripts/bfasst/design.py
+++ b/scripts/bfasst/design.py
@@ -155,7 +155,7 @@ class Design:
                 self.path,
             )
 
-        return top_paths[0]
+        return list(valid_paths)[0]
 
     def hdl_by_suffix(self, *suffixes):
         return (

--- a/scripts/bfasst/design.py
+++ b/scripts/bfasst/design.py
@@ -155,7 +155,7 @@ class Design:
                 self.path,
             )
 
-        return list(valid_paths)[0]
+        return next(valid_paths)
 
     def hdl_by_suffix(self, *suffixes):
         return (


### PR DESCRIPTION
I opened an issue bfasst not handing system verilog files, I tracked down the issue to this line of code. This edit seems to fix the issue by getting the only top file from the filtered list rather than by assuming that the list will always return a verilog file. Feel free to suggest a better way to do this if there is one, but I figured this should make fixing the issue a lot easier.