### PR TITLE
Add reverse to argparse

### DIFF
--- a/scripts/bfasst/tool_wrappers.py
+++ b/scripts/bfasst/tool_wrappers.py
@@ -92,7 +92,7 @@ def onespin_cmp(design, build_dir, flow_args):
     """Compare netlists using Onespin"""
     from bfasst.compare.onespin import OneSpin_CompareTool
 
-    compare_tool = OneSpin_CompareTool(build_dir, flow_args)
+    compare_tool = OneSpin_CompareTool(build_dir, flow_args[ToolType.CMP])
     with onespin_lock:
         return compare_tool.compare_netlists(design)
 
@@ -121,7 +121,7 @@ def xray_rev(design, build_dir, flow_args):
     """Reverse bitstream using Xray"""
     from bfasst.reverse_bit.xray import XRayReverseBitTool
 
-    reverse_bit_tool = XRayReverseBitTool(build_dir, flow_args)
+    reverse_bit_tool = XRayReverseBitTool(build_dir, flow_args[ToolType.REVERSE])
     return reverse_bit_tool.reverse_bitstream(design)
 
 

--- a/scripts/run_design.py
+++ b/scripts/run_design.py
@@ -33,54 +33,55 @@ def run_design(design_path, flow, error_flow, flow_args):
     print(status)
 
 
-def main():
-    """Parse argument and run design"""
+# def main():
+"""Parse argument and run design"""
 
-    parser = ArgumentParser()
+parser = ArgumentParser()
 
-    parser.add_argument("design_path", help="Path to design in examples directory.")
-    parser.add_argument("flow", choices=[e.value for e in Flows])
-    parser.add_argument("--synth", help="Synthesis args", nargs=1, type=str, default="")
-    parser.add_argument("--impl", help="Implementation args", nargs=1, type=str, default="")
-    parser.add_argument("--map", help="Mapping args", nargs=1, type=str, default="")
-    parser.add_argument("--cmp", help="Comparison args", nargs=1, type=str, default="")
-    parser.add_argument("--err", help="Error flow args", nargs=1, type=str, default="")
-    parser.add_argument("--quiet", action="store_true")
+parser.add_argument("design_path", help="Path to design in examples directory.")
+parser.add_argument("flow", choices=[e.value for e in Flows])
+parser.add_argument("--synth", help="Synthesis args", nargs=1, type=str, default="")
+parser.add_argument("--impl", help="Implementation args", nargs=1, type=str, default="")
+parser.add_argument("--map", help="Mapping args", nargs=1, type=str, default="")
+parser.add_argument("--cmp", help="Comparison args", nargs=1, type=str, default="")
+parser.add_argument("--reverse", help="Reverse args", nargs=1, type=str, default="")
+parser.add_argument("--err", help="Error flow args", nargs=1, type=str, default="")
+parser.add_argument("--quiet", action="store_true")
 
-    error_flows = []
-    for dir_item in paths.ERROR_FLOW_PATH.iterdir():
-        if (paths.EXPERIMENTS_PATH / dir_item).is_file() and dir_item.suffix == ".yaml":
-            error_flows.append(dir_item.stem)
-    parser.add_argument(
-        "--error_flow",
-        choices=error_flows,
-        help=(
-            "YAML file describing errors to inject for testing."
-            "Only works with flows designed for error injection"
-        ),
-    )
-    args = parser.parse_args()
+error_flows = []
+for dir_item in paths.ERROR_FLOW_PATH.iterdir():
+    if (paths.EXPERIMENTS_PATH / dir_item).is_file() and dir_item.suffix == ".yaml":
+        error_flows.append(dir_item.stem)
+parser.add_argument(
+    "--error_flow",
+    choices=error_flows,
+    help=(
+        "YAML file describing errors to inject for testing."
+        "Only works with flows designed for error injection"
+    ),
+)
+args = parser.parse_args()
 
-    # Build per-tool arguments into flow_args dictionary
-    flow_args = defaultdict(str)
-    flow_args_map = {
-        "synth": ToolType.SYNTH,
-        "impl": ToolType.IMPL,
-        "map": ToolType.MAP,
-        "cmp": ToolType.CMP,
-        "reverse": ToolType.REVERSE,
-    }
-    print(flow_args[ToolType.SYNTH])
-    for arg_name, enum in flow_args_map.items():
-        flow_args[enum] = getattr(args, arg_name)
+# Build per-tool arguments into flow_args dictionary
+flow_args = defaultdict(str)
+flow_args_map = {
+    "synth": ToolType.SYNTH,
+    "impl": ToolType.IMPL,
+    "map": ToolType.MAP,
+    "cmp": ToolType.CMP,
+    "reverse": ToolType.REVERSE,
+}
+print(flow_args[ToolType.SYNTH])
+for arg_name, enum in flow_args_map.items():
+    flow_args[enum] = getattr(args, arg_name)
 
-    design_path = Path(args.design_path)
-    if not design_path.is_dir() and (paths.EXAMPLES_PATH / design_path).is_dir():
-        design_path = paths.EXAMPLES_PATH / design_path
-    design_path = design_path.absolute()
+design_path = Path(args.design_path)
+if not design_path.is_dir() and (paths.EXAMPLES_PATH / design_path).is_dir():
+    design_path = paths.EXAMPLES_PATH / design_path
+design_path = design_path.absolute()
 
-    run_design(design_path, args.flow, args.error_flow, flow_args=flow_args)
+run_design(design_path, args.flow, args.error_flow, flow_args=flow_args)
 
 
-if __name__ == "__main__":
-    main()
+# if __name__ == "__main__":
+#     main()

--- a/scripts/run_design.py
+++ b/scripts/run_design.py
@@ -33,55 +33,55 @@ def run_design(design_path, flow, error_flow, flow_args):
     print(status)
 
 
-# def main():
-"""Parse argument and run design"""
+def main():
+    """Parse argument and run design"""
 
-parser = ArgumentParser()
+    parser = ArgumentParser()
 
-parser.add_argument("design_path", help="Path to design in examples directory.")
-parser.add_argument("flow", choices=[e.value for e in Flows])
-parser.add_argument("--synth", help="Synthesis args", nargs=1, type=str, default="")
-parser.add_argument("--impl", help="Implementation args", nargs=1, type=str, default="")
-parser.add_argument("--map", help="Mapping args", nargs=1, type=str, default="")
-parser.add_argument("--cmp", help="Comparison args", nargs=1, type=str, default="")
-parser.add_argument("--reverse", help="Reverse args", nargs=1, type=str, default="")
-parser.add_argument("--err", help="Error flow args", nargs=1, type=str, default="")
-parser.add_argument("--quiet", action="store_true")
+    parser.add_argument("design_path", help="Path to design in examples directory.")
+    parser.add_argument("flow", choices=[e.value for e in Flows])
+    parser.add_argument("--synth", help="Synthesis args", nargs=1, type=str, default="")
+    parser.add_argument("--impl", help="Implementation args", nargs=1, type=str, default="")
+    parser.add_argument("--map", help="Mapping args", nargs=1, type=str, default="")
+    parser.add_argument("--cmp", help="Comparison args", nargs=1, type=str, default="")
+    parser.add_argument("--reverse", help="Reverse args", nargs=1, type=str, default="")
+    parser.add_argument("--err", help="Error flow args", nargs=1, type=str, default="")
+    parser.add_argument("--quiet", action="store_true")
 
-error_flows = []
-for dir_item in paths.ERROR_FLOW_PATH.iterdir():
-    if (paths.EXPERIMENTS_PATH / dir_item).is_file() and dir_item.suffix == ".yaml":
-        error_flows.append(dir_item.stem)
-parser.add_argument(
-    "--error_flow",
-    choices=error_flows,
-    help=(
-        "YAML file describing errors to inject for testing."
-        "Only works with flows designed for error injection"
-    ),
-)
-args = parser.parse_args()
+    error_flows = []
+    for dir_item in paths.ERROR_FLOW_PATH.iterdir():
+        if (paths.EXPERIMENTS_PATH / dir_item).is_file() and dir_item.suffix == ".yaml":
+            error_flows.append(dir_item.stem)
+    parser.add_argument(
+        "--error_flow",
+        choices=error_flows,
+        help=(
+            "YAML file describing errors to inject for testing."
+            "Only works with flows designed for error injection"
+        ),
+    )
+    args = parser.parse_args()
 
-# Build per-tool arguments into flow_args dictionary
-flow_args = defaultdict(str)
-flow_args_map = {
-    "synth": ToolType.SYNTH,
-    "impl": ToolType.IMPL,
-    "map": ToolType.MAP,
-    "cmp": ToolType.CMP,
-    "reverse": ToolType.REVERSE,
-}
-print(flow_args[ToolType.SYNTH])
-for arg_name, enum in flow_args_map.items():
-    flow_args[enum] = getattr(args, arg_name)
+    # Build per-tool arguments into flow_args dictionary
+    flow_args = defaultdict(str)
+    flow_args_map = {
+        "synth": ToolType.SYNTH,
+        "impl": ToolType.IMPL,
+        "map": ToolType.MAP,
+        "cmp": ToolType.CMP,
+        "reverse": ToolType.REVERSE,
+    }
+    print(flow_args[ToolType.SYNTH])
+    for arg_name, enum in flow_args_map.items():
+        flow_args[enum] = getattr(args, arg_name)
 
-design_path = Path(args.design_path)
-if not design_path.is_dir() and (paths.EXAMPLES_PATH / design_path).is_dir():
-    design_path = paths.EXAMPLES_PATH / design_path
-design_path = design_path.absolute()
+    design_path = Path(args.design_path)
+    if not design_path.is_dir() and (paths.EXAMPLES_PATH / design_path).is_dir():
+        design_path = paths.EXAMPLES_PATH / design_path
+    design_path = design_path.absolute()
 
-run_design(design_path, args.flow, args.error_flow, flow_args=flow_args)
+    run_design(design_path, args.flow, args.error_flow, flow_args=flow_args)
 
 
-# if __name__ == "__main__":
-#     main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Parsing flow args was throwing an error because "reverse" was not part of the argparse namespace in run_design.py