### PR TITLE
Phys netlist: check mux7/8 and carry4 mapping

### DIFF
--- a/bfasst/status.py
+++ b/bfasst/status.py
@@ -83,6 +83,7 @@ msg_map = {
     ErrorInjectionStatus.FCN_SUCCESS: "FCN Successful",
     ErrorInjectionStatus.FCN_ERROR: "FCN Error",
     TransformStatus.SUCCESS: "Transform Success",
+    TransformStatus.ERROR: "Transform Error",
 }
 
 

--- a/bfasst/transform/xilinx_phys_netlist.py
+++ b/bfasst/transform/xilinx_phys_netlist.py
@@ -41,6 +41,41 @@ class XilinxPhysNetlist(TransformTool):
     success_status = Status(TransformStatus.SUCCESS)
     TOOL_WORK_DIR = "xilinx_phys_netlist"
 
+    STD_PIN_MAP_BY_CELL = {
+        "MUXF7": {
+            "I0": "0",
+            "I1": "1",
+            "S": "S0",
+            "O": "OUT",
+        },
+        "MUXF8": {
+            "I0": "0",
+            "I1": "1",
+            "S": "S0",
+            "O": "OUT",
+        },
+        "CARRY4": {
+            "DI[3]": "DI3",
+            "DI[2]": "DI2",
+            "DI[1]": "DI1",
+            "DI[0]": "DI0",
+            "CI": "CIN",
+            "CO[3]": "CO3",
+            "CO[2]": "CO2",
+            "CO[1]": "CO1",
+            "CO[0]": "CO0",
+            "O[3]": "O3",
+            "O[2]": "O2",
+            "O[1]": "O1",
+            "O[0]": "O0",
+            "S[3]": "S3",
+            "S[2]": "S2",
+            "S[1]": "S1",
+            "S[0]": "S0",
+            "CYINIT": "CYINIT",
+        },
+    }
+
     def run(self, design):
         """Transform the logical netlist into a netlist with only physical primitives"""
         phys_netlist_verilog_path = design.impl_edif_path.parent / (
@@ -135,51 +170,30 @@ class XilinxPhysNetlist(TransformTool):
 
             # Handle LUT cells
             if fnmatch(str(cell.getBELName()), "??LUT"):
-                # Check if there is another LUT at this site/bel
-                other_lut_cell = None
-                other_cells_at_this_bel = [
-                    other_cell
-                    for other_cell in cell.getSiteInst().getCells()
-                    if fnmatch(str(other_cell.getBELName()), f"{str(cell.getBELName())[0]}?LUT")
-                    and other_cell != cell
-                ]
-                # Shouldn't have more than one other LUT at this location
-                assert len(other_cells_at_this_bel) <= 1
-
-                if other_cells_at_this_bel:
-                    other_lut_cell = other_cells_at_this_bel[0]
-                    cells_already_visited.add(other_lut_cell)
-
-                # Determine which is the LUT6 vs LUT5
-                if not other_lut_cell:
-                    lut6_cell = cell
-                    lut5_cell = None
-                elif self.cell_is_6lut(cell):
-                    lut6_cell = cell
-                    lut5_cell = other_lut_cell
-                else:
-                    lut6_cell = other_lut_cell
-                    lut5_cell = cell
-
-                assert self.cell_is_6lut(lut6_cell)
-                assert lut5_cell is None or self.cell_is_5lut(lut5_cell)
-
                 # Replace the LUT(s) with a LUT2_6
-                self.process_lut(lut6_cell, lut5_cell, lut6_2_edif_cell)
+                cells_to_remove.extend(
+                    self.process_lut(cell, lut6_2_edif_cell, cells_already_visited)
+                )
+                continue
 
-                if not lut6_cell.isRoutethru():
-                    cells_to_remove.append(lut6_cell)
-                if lut5_cell and not lut5_cell.isRoutethru():
-                    cells_to_remove.append(lut5_cell)
+            if edif_cell_inst.getCellType().getName() in ("MUXF7", "MUXF8"):
+                self.process_muxf7_muxf8(cell)
+                continue
+
+            if edif_cell_inst.getCellType().getName() in ("CARRY4",):
+                self.process_carry4(cell)
                 continue
 
             # These primitives don't need to get transformed
-            if cell.getBELName() in ("INBUF_EN", "OUTBUF", "AFF", "BFF", "CFF", "DFF", "PAD"):
+            if edif_cell_inst.getCellType().getName() in ("IBUF", "OBUF", "OBUFT", "FDSE", "FDRE"):
                 continue
 
             # TODO: Handle other primitives? RAM*, BUFG->BUFGCTRL, etc.
             print(cell)
-            return Status(TransformStatus.ERROR, f"Unhandled primitive {cell.getBELName()}")
+            return Status(
+                TransformStatus.ERROR,
+                f"Unhandled primitive {edif_cell_inst.getCellType().getName()}",
+            )
 
         # Remove old unusued cells
         self.log("Removing old cells...")
@@ -236,9 +250,93 @@ class XilinxPhysNetlist(TransformTool):
         self.log("Exported new netlist to", phys_netlist_verilog_path)
         return self.success_status
 
-    def process_lut(self, lut6_cell, lut5_cell, lut6_2_cell):
+    def cell_is_default_mapping(self, cell):
+        """This checks whether the cell is using the default logical to physical mappings"""
+        type_name = cell.getEDIFCellInst().getCellType().getName()
+        default_l2p_map = XilinxPhysNetlist.STD_PIN_MAP_BY_CELL[type_name]
+
+        l2p = cell.getPinMappingsL2P()
+        permuted = False
+        for logical, physical in default_l2p_map.items():
+            if logical in l2p and list(l2p[logical]) != [physical]:
+                print(list(l2p[logical]), "<>", [physical])
+                permuted = True
+                break
+
+        return permuted
+
+    def process_muxf7_muxf8(self, cell):
+        """Process MUXF7/MUXF8 primitive
+        Not sure whether inputs can be permuted or not, but for now let's
+        assume they can't be and throw a NotImplementedError exception if
+        they are permuted in some way."""
+
+        type_name = cell.getEDIFCellInst().getCellType().getName()
+        self.log_color(TermColor.BLUE, f"\nProcessing {type_name}", cell)
+
+        permuted = self.cell_is_default_mapping(cell)
+        if not permuted:
+            self.log("  Inputs not permuted, skipping")
+            return []
+
+        raise NotImplementedError
+
+    def process_carry4(self, cell):
+        """Process CARRY4 primitive
+        Not sure whether inputs can be permuted or not, but for now let's
+        assume they can't be and throw a NotImplementedError exception if
+        they are permuted in some way."""
+        type_name = cell.getEDIFCellInst().getCellType().getName()
+        self.log_color(TermColor.BLUE, f"\nProcessing {type_name}", cell)
+
+        print(cell.getPinMappingsL2P())
+        permuted = self.cell_is_default_mapping(cell)
+        if not permuted:
+            self.log("  Inputs not permuted, skipping")
+            return []
+
+        raise NotImplementedError
+
+    def get_lut6_lut5_for_given_lut_cell(self, cell, cells_already_visited):
+        """For a given LUT cell, determine the LUT6 and LUT5 at the
+        location and return them"""
+
+        # Check if there is another LUT at this site/bel
+        other_lut_cell = None
+        other_cells_at_this_bel = [
+            other_cell
+            for other_cell in cell.getSiteInst().getCells()
+            if fnmatch(str(other_cell.getBELName()), f"{str(cell.getBELName())[0]}?LUT")
+            and other_cell != cell
+        ]
+        # Shouldn't have more than one other LUT at this location
+        assert len(other_cells_at_this_bel) <= 1
+
+        if other_cells_at_this_bel:
+            other_lut_cell = other_cells_at_this_bel[0]
+            cells_already_visited.add(other_lut_cell)
+
+        # Determine which is the LUT6 vs LUT5
+        if not other_lut_cell:
+            lut6_cell = cell
+            lut5_cell = None
+        elif self.cell_is_6lut(cell):
+            lut6_cell = cell
+            lut5_cell = other_lut_cell
+        else:
+            lut6_cell = other_lut_cell
+            lut5_cell = cell
+
+        assert self.cell_is_6lut(lut6_cell)
+        assert lut5_cell is None or self.cell_is_5lut(lut5_cell)
+
+        return (lut6_cell, lut5_cell)
+
+    def process_lut(self, cell, lut6_2_cell, cells_already_visited):
         """This function takes a LUT* from the netlist and replaces with with a LUT6_2
         with logical mapping equal to the physical mapping."""
+
+        lut6_cell, lut5_cell = self.get_lut6_lut5_for_given_lut_cell(cell, cells_already_visited)
 
         self.log_color(
             TermColor.BLUE,
@@ -321,6 +419,14 @@ class XilinxPhysNetlist(TransformTool):
 
         # Fix the new LUT INIT property based on the new pin mappings
         self.process_lut_init(lut6_cell, lut5_cell, new_cell_inst)
+
+        # Return the cells to be removed
+        cells_to_remove = []
+        if not lut6_cell.isRoutethru():
+            cells_to_remove.append(lut6_cell)
+        if lut5_cell and not lut5_cell.isRoutethru():
+            cells_to_remove.append(lut5_cell)
+        return cells_to_remove
 
     def create_lut_routethru_net(self, cell, is_lut5, new_lut_cell):
         """Extra processing for LUT route through.  Need to create a new net


### PR DESCRIPTION
This is a simple attempt at handling muxf7, muxf8 and carry4.  It only verifies that the pin mappings are default (equivalent to logical netlist) and haven't been permuted in the physical design.