### PR TITLE
Remove try/except clause

### DIFF
--- a/bfasst/transform/xilinx_phys_netlist.py
+++ b/bfasst/transform/xilinx_phys_netlist.py
@@ -194,7 +194,6 @@ class XilinxPhysNetlist(TransformTool):
         self.rw_design = Design.readCheckpoint(
             design.xilinx_impl_checkpoint_path, design.impl_edif_path
         )
-        
         self.rw_netlist = self.rw_design.getNetlist()
 
         # Init BUFGCTRL cell template

--- a/bfasst/transform/xilinx_phys_netlist.py
+++ b/bfasst/transform/xilinx_phys_netlist.py
@@ -191,18 +191,10 @@ class XilinxPhysNetlist(TransformTool):
         """Do all rapidwright related processing on the netlist"""
 
         # Read the checkpoint into rapidwright, and get the netlist
-        try:
-            self.rw_design = Design.readCheckpoint(
-                design.xilinx_impl_checkpoint_path, design.impl_edif_path
-            )
-        except jpype.JException as exc:
-            error = str(exc)
-            if "Failed to reliably download file" not in error:
-                raise RapidwrightException(error)           # pylint: disable=raise-missing-from
-            self.rw_design = Design.readCheckpoint(
+        self.rw_design = Design.readCheckpoint(
             design.xilinx_impl_checkpoint_path, design.impl_edif_path
-            )
-
+        )
+        
         self.rw_netlist = self.rw_design.getNetlist()
 
         # Init BUFGCTRL cell template


### PR DESCRIPTION
Remove Try/Except clause for when part db doesn't download correctly - this is now fixed by pre-downloading parts during install.