### PR TITLE
exception and status refactor

### DIFF
--- a/bfasst/bfasst_exception.py
+++ b/bfasst/bfasst_exception.py
@@ -1,0 +1,5 @@
+"""Base class for all tool exceptions in the bfasst package."""
+
+
+class BfasstException(Exception):
+    """Base class for all tool exceptions in the bfasst package."""

--- a/bfasst/bfasst_exception.py
+++ b/bfasst/bfasst_exception.py
@@ -1,5 +1,0 @@
-"""Base class for all tool exceptions in the bfasst package."""
-
-
-class BfasstException(Exception):
-    """Base class for all tool exceptions in the bfasst package."""

--- a/bfasst/compare/base.py
+++ b/bfasst/compare/base.py
@@ -6,6 +6,11 @@ from bfasst.status import CompareStatus, Status
 
 from bfasst.tool import Tool, ToolProduct
 from bfasst.utils import print_color
+from bfasst.bfasst_exception import BfasstException
+
+
+class CompareException(BfasstException):
+    """Base class for all exceptions in the compare package"""
 
 
 class CompareTool(Tool):

--- a/bfasst/compare/base.py
+++ b/bfasst/compare/base.py
@@ -6,7 +6,7 @@ from bfasst.status import CompareStatus, Status
 
 from bfasst.tool import Tool, ToolProduct
 from bfasst.utils import print_color
-from bfasst.bfasst_exception import BfasstException
+from bfasst.tool import BfasstException
 
 
 class CompareException(BfasstException):

--- a/bfasst/compare/base.py
+++ b/bfasst/compare/base.py
@@ -2,8 +2,6 @@
 import abc
 import pathlib
 
-from bfasst.status import CompareStatus, Status
-
 from bfasst.tool import Tool, ToolProduct
 from bfasst.utils import print_color
 from bfasst.tool import BfasstException
@@ -15,8 +13,6 @@ class CompareException(BfasstException):
 
 class CompareTool(Tool):
     """Base class for comparison tools"""
-
-    success_status = Status(CompareStatus.SUCCESS)
 
     LOG_FILE_NAME = "log.txt"
 
@@ -51,16 +47,15 @@ class CompareTool(Tool):
 
     def up_to_date(self, check_log_fcn):
         """Determine whether to skip or run the comparison"""
-        status = self.get_prev_run_status(
+        if not self.need_to_rerun(
             tool_products=(self.generate_comparison(check_log_fcn),),
             dependency_modified_time=max(
                 pathlib.Path(__file__).stat().st_mtime,
                 self.design.reversed_netlist_path.stat().st_mtime,
             ),
-        )
-
-        if status is not None:
+        ):
             self.print_skipping_compare()
+            return True
 
         self.print_running_compare()
-        return status
+        return False

--- a/bfasst/compare/conformal.py
+++ b/bfasst/compare/conformal.py
@@ -14,8 +14,8 @@ import scp
 import bfasst
 from bfasst import paths
 from bfasst.design import HdlType
-from bfasst.status import BfasstException, Status, CompareStatus
-from bfasst.compare.base import CompareTool
+from bfasst.tool import BfasstException
+from bfasst.compare.base import CompareException, CompareTool
 from bfasst.types import Vendor
 from bfasst.utils import error
 
@@ -85,24 +85,16 @@ class ConformalCompareTool(CompareTool):
 
         # Run conformal remotely
         try:
-            status = self.run_conformal(client)
+            self.run_conformal(client)
         except BfasstException as e:
-            if e.error != CompareStatus.TIMEOUT:
-                raise e
-            status = e
+            raise e
 
         # Copy back conformal log file
         self.copy_log_from_remote_machine(client)
         client.close()
 
-        if status.status == CompareStatus.TIMEOUT:
-            with open(log_path, "a") as fp:
-                fp.write("\nTimeout\n")
-
         # Check conformal log
-        status = self.check_compare_status(log_path)
-
-        return self.success_status
+        self.check_compare_status(log_path)
 
     def connect_to_remote_machine(self):
         client = paramiko.SSHClient()
@@ -138,14 +130,12 @@ class ConformalCompareTool(CompareTool):
         try:
             stdout.read()
             stdout.channel.recv_exit_status()
-        except socket.timeout:
-            return Status(CompareStatus.TIMEOUT)
+        except socket.timeout as e:
+            raise CompareException("The conformal tool timed out") from e
 
         stderr = stderr.read().decode()
         if "License check failed" in stderr:
-            return Status(CompareStatus.NO_LICENSE)
-
-        return Status(CompareStatus.SUCCESS)
+            raise CompareException("The conformal tool failed to run due to license issues")
 
     def create_do_file(self):
         """Create the conformal do file"""
@@ -259,12 +249,11 @@ class ConformalCompareTool(CompareTool):
 
         # Check for timeout
         if re.search(r"^Timeout$", log_text, re.M):
-            return Status(CompareStatus.TIMEOUT)
+            raise CompareException("Conformal timed out")
 
         # Regex search for result
         match = re.search(r"^6\. Compare Results:\s+(.*)$", log_text, re.M)
         if not match:
-            return Status(CompareStatus.PARSE_PROBLEM)
-        if match.group(1) == "PASS":
-            return Status(CompareStatus.SUCCESS)
-        return Status(CompareStatus.NOT_EQUIVALENT, match.group(1))
+            raise CompareException("There was a parse problem with the comparison log file")
+        if match.group(1) != "PASS":
+            raise CompareException("The netlists are not equivalent")

--- a/bfasst/compare/conformal.py
+++ b/bfasst/compare/conformal.py
@@ -40,9 +40,8 @@ class ConformalCompareTool(CompareTool):
 
     def compare_netlists(self):
         """Compare given netlists"""
-        status = self.up_to_date(self.check_compare_status)
-        if status is not None:
-            return status
+        if self.up_to_date(self.check_compare_status):
+            return
 
         log_path = self.work_dir / self.LOG_FILE_NAME
 

--- a/bfasst/compare/onespin.py
+++ b/bfasst/compare/onespin.py
@@ -6,7 +6,6 @@ import yaml
 
 from bfasst import paths
 from bfasst.compare.base import CompareTool
-from bfasst.status import Status, CompareStatus
 
 ONESPIN_TCL_TEMPLATE = "run_onespin.tcl"
 ONESPIN_PY_TEMPLATE = "run_onespin.py"
@@ -60,8 +59,6 @@ class OneSpinCompareTool(CompareTool):
             yaml.dump(yaml_data, fp)
 
         self.write_compare_tcl()
-
-        return Status(CompareStatus.NEED_TO_RUN_ONESPIN)
 
     def read_golden(self, fp, gold_is_rtl):
         """Read the golden file."""

--- a/bfasst/compare/structural.py
+++ b/bfasst/compare/structural.py
@@ -360,7 +360,7 @@ class StructuralCompareTool(CompareTool):
         if cell_type in ("IBUF", "OBUF", "OBUFT", "MUXF7", "MUXF8", "CARRY4"):
             return ()
 
-        raise KeyError(f"Unhandled properties for type {cell_type}")
+        raise CompareException(f"Unhandled properties for type {cell_type}")
 
     def get_netlist(self, library):
         return Netlist(library, self)

--- a/bfasst/compare/waveform.py
+++ b/bfasst/compare/waveform.py
@@ -88,9 +88,8 @@ class WaveformCompareTool(CompareTool):
         print(f"Displaying waveforms via Gtkwave: {self.args.waveform}")
         print(f"Displaying waveforms via Vivado: {self.args.vivado}\n")
 
-        status = self.up_to_date(self.check_compare_status)
-        if status is not None:
-            return status
+        if self.up_to_date(self.check_compare_status):
+            return
 
         self.print_running_compare()
 

--- a/bfasst/compare/yosys.py
+++ b/bfasst/compare/yosys.py
@@ -17,9 +17,8 @@ class YosysCompareTool(CompareTool):
 
         generate_comparison = ToolProduct(None, log_path, self.check_compare_status)
 
-        status = self.up_to_date(generate_comparison)
-        if status is not None:
-            return status
+        if self.up_to_date(generate_comparison):
+            return
 
         # Run Yosys
         cmd = ["./yosys", self.create_script_file()]

--- a/bfasst/compare/yosys.py
+++ b/bfasst/compare/yosys.py
@@ -1,8 +1,7 @@
 """Yosys equivalence checker"""
 import pathlib
 import re
-from bfasst.compare.base import CompareTool
-from bfasst.status import Status, CompareStatus
+from bfasst.compare.base import CompareException, CompareTool
 from bfasst.tool import ToolProduct
 
 
@@ -27,8 +26,7 @@ class YosysCompareTool(CompareTool):
         cwd = str(pathlib.Path.cwd()) + "/third_party/yosys"
         with open(log_path, "w") as fp:
             if self.exec_and_log(cmd, cwd, fp).returncode:
-                return Status(CompareStatus.NOT_EQUIVALENT)
-        return Status(CompareStatus.SUCCESS)
+                raise CompareException("The netlists are not equivalent")
 
     def create_script_file(self):
         """Creates a Tcl script that asserts equivalence between the two designs"""
@@ -95,15 +93,15 @@ class YosysCompareTool(CompareTool):
 
         # Check for timeout
         if re.search(r"^Timeout$", log_text, re.M):
-            return Status(CompareStatus.TIMEOUT)
+            raise CompareException("The yosys tool timed out")
 
         # Regex search for result
         match = re.search(r"Equivalence successfully proven!", log_text, re.M)
         if match:
-            return Status(CompareStatus.SUCCESS)
+            return
 
         match = re.search(r"ERROR", log_text, re.M)
         if match:
-            return Status(CompareStatus.NOT_EQUIVALENT)
+            raise CompareException("The netlists are not equivalent")
 
-        return Status(CompareStatus.PARSE_PROBLEM)
+        raise CompareException("There was a parsing error in the yosys log file")

--- a/bfasst/error_injection/base.py
+++ b/bfasst/error_injection/base.py
@@ -3,7 +3,7 @@ import abc
 
 from bfasst.tool import Tool
 from bfasst.status import Status, ErrorInjectionStatus
-from bfasst.bfasst_exception import BfasstException
+from bfasst.tool import BfasstException
 
 
 class ErrorInjectionException(BfasstException):

--- a/bfasst/error_injection/base.py
+++ b/bfasst/error_injection/base.py
@@ -2,7 +2,6 @@
 import abc
 
 from bfasst.tool import Tool
-from bfasst.status import Status, ErrorInjectionStatus
 from bfasst.tool import BfasstException
 
 
@@ -12,8 +11,6 @@ class ErrorInjectionException(BfasstException):
 
 class ErrorInjectionTool(Tool):
     """Base class for error injection tools"""
-
-    success_status = Status(ErrorInjectionStatus.SUCCESS)
 
     def __init__(self, cwd, design, flow_args="") -> None:
         super().__init__(cwd, design)

--- a/bfasst/error_injection/base.py
+++ b/bfasst/error_injection/base.py
@@ -3,6 +3,11 @@ import abc
 
 from bfasst.tool import Tool
 from bfasst.status import Status, ErrorInjectionStatus
+from bfasst.bfasst_exception import BfasstException
+
+
+class ErrorInjectionException(BfasstException):
+    """Base class for all exceptions in the error injection package"""
 
 
 class ErrorInjectionTool(Tool):

--- a/bfasst/impl/base.py
+++ b/bfasst/impl/base.py
@@ -5,7 +5,7 @@ import pathlib
 from bfasst.status import ImplStatus, Status
 from bfasst.utils import print_color
 from bfasst.tool import Tool, ToolProduct
-from bfasst.bfasst_exception import BfasstException
+from bfasst.tool import BfasstException
 
 
 class ImplementationException(BfasstException):

--- a/bfasst/impl/base.py
+++ b/bfasst/impl/base.py
@@ -41,20 +41,18 @@ class ImplementationTool(Tool):
     def print_skipping_impl(self):
         print_color(self.TERM_COLOR_STAGE, "Implementation already run")
 
-    def common_startup(self, log_check_fcn):
+    def up_to_date(self, log_check_fcn):
         """Commmon startup code for Implementation tools that first checks if
         prevous run can be used, and if not starts a new run"""
-        status = self.get_prev_run_status(
+        if not self.need_to_rerun(
             tool_products=[ToolProduct(self.design.bitstream_path, self.log_path, log_check_fcn)],
             dependency_modified_time=max(
                 pathlib.Path(__file__).stat().st_mtime, self.design.netlist_path.stat().st_mtime
             ),
-        )
-
-        if status is not None:
+        ):
             self.print_skipping_impl()
-            return status
+            return True
 
         self.print_running_impl()
         self.open_new_log()
-        return None
+        return False

--- a/bfasst/impl/base.py
+++ b/bfasst/impl/base.py
@@ -2,7 +2,6 @@
 import abc
 import pathlib
 
-from bfasst.status import ImplStatus, Status
 from bfasst.utils import print_color
 from bfasst.tool import Tool, ToolProduct
 from bfasst.tool import BfasstException
@@ -14,8 +13,6 @@ class ImplementationException(BfasstException):
 
 class ImplementationTool(Tool):
     """Base class for implementation tools"""
-
-    success_status = Status(ImplStatus.SUCCESS)
 
     def __init__(self, cwd, design, flow_args="") -> None:
         super().__init__(cwd, design)

--- a/bfasst/impl/base.py
+++ b/bfasst/impl/base.py
@@ -5,6 +5,11 @@ import pathlib
 from bfasst.status import ImplStatus, Status
 from bfasst.utils import print_color
 from bfasst.tool import Tool, ToolProduct
+from bfasst.bfasst_exception import BfasstException
+
+
+class ImplementationException(BfasstException):
+    """Base class for all exceptions in the implementation package"""
 
 
 class ImplementationTool(Tool):

--- a/bfasst/impl/ic2.py
+++ b/bfasst/impl/ic2.py
@@ -18,9 +18,8 @@ class Ic2ImplementationTool(ImplementationTool):
     def implement_bitstream(self):
         self.design.bitstream_path = self.cwd / (self.design.top + ".bit")
 
-        status = self.common_startup(self.check_impl_status)
-        if status:
-            return status
+        if self.up_to_date(self.check_impl_status):
+            return
 
         # Create impl tcl script
         tcl_path = self.create_run_tcl()

--- a/bfasst/impl/ic2.py
+++ b/bfasst/impl/ic2.py
@@ -7,8 +7,7 @@ import os
 
 import bfasst
 from bfasst import paths
-from bfasst.impl.base import ImplementationTool
-from bfasst.status import Status, ImplStatus
+from bfasst.impl.base import ImplementationTool, ImplementationException
 
 
 class Ic2ImplementationTool(ImplementationTool):
@@ -31,10 +30,10 @@ class Ic2ImplementationTool(ImplementationTool):
         shutil.copyfile(self.design.netlist_path, new_netlist_path)
 
         # Run implementation
-        status = self.run_implementation(new_netlist_path, tcl_path)
+        self.run_implementation(new_netlist_path, tcl_path)
 
         # Check implementation log
-        status = self.check_impl_status(self.log_path)
+        self.check_impl_status(self.log_path)
 
         # if need_to_run:
         # Copy bitstream out of working directory
@@ -43,8 +42,8 @@ class Ic2ImplementationTool(ImplementationTool):
         )
         try:
             shutil.copyfile(bitstream_proj_path, self.design.bitstream_path)
-        except FileNotFoundError:
-            return Status(ImplStatus.ERROR)
+        except FileNotFoundError as e:
+            raise ImplementationException("File not found: " + str(bitstream_proj_path)) from e
 
         # Copy constraints out of working directory
         constraints_proj_path = (
@@ -53,13 +52,11 @@ class Ic2ImplementationTool(ImplementationTool):
         self.design.constraints_path = self.cwd / (self.design.top + ".pcf")
         try:
             shutil.copyfile(constraints_proj_path, self.design.constraints_path)
-        except FileNotFoundError:
-            return Status(ImplStatus.ERROR)
+        except FileNotFoundError as e:
+            raise ImplementationException("File not found: " + str(constraints_proj_path)) from e
 
         # Always set the constraints path since we need it later
         # design.constraints_path = self.cwd/(design.top + ".pcf")
-
-        return Status(ImplStatus.SUCCESS)
 
     def run_implementation(self, netlist_path, tcl_path):
         """Run implemention"""
@@ -73,9 +70,7 @@ class Ic2ImplementationTool(ImplementationTool):
                 cmd, stdout=fp, stderr=subprocess.STDOUT, cwd=self.work_dir, env=env
             )
             if proc.returncode != 0:
-                return Status(ImplStatus.ERROR)
-
-        return Status(ImplStatus.SUCCESS)
+                raise ImplementationException("IceCube2 failed while running tcl script")
 
     def create_run_tcl(self):
         tcl_path = self.work_dir / "run_impl.tcl"
@@ -90,12 +85,12 @@ class Ic2ImplementationTool(ImplementationTool):
             r"^Design LUT Count \((\d+)\) exceeded Device LUT Count \((\d+)\)$", text, re.M
         )
         if match:
-            return Status(ImplStatus.TOO_MANY_LUTS, match.group(1) + "/" + match.group(2))
+            raise ImplementationException("Too many luts: " + match.group(1) + "/" + match.group(2))
         match = re.search(
             r"^Design FF Count \((\d+)\) exceeded Device FF Count \((\d+)\)$", text, re.M
         )
         if match:
-            return Status(ImplStatus.TOO_MANY_FF, match.group(1) + "/" + match.group(2))
+            raise ImplementationException("Too many FF: " + match.group(1) + "/" + match.group(2))
 
         # Too many I/Os
         match = re.search(
@@ -107,7 +102,7 @@ class Ic2ImplementationTool(ImplementationTool):
             re.M | re.S,
         )
         if match:
-            return Status(ImplStatus.TOO_MANY_IO, match.group(2) + "/" + match.group(1))
+            raise ImplementationException("Too many IO: " + match.group(2) + "/" + match.group(1))
 
         # if too_large_str:
         #     err_str += "Design does not fit. " + too_large_str
@@ -120,8 +115,6 @@ class Ic2ImplementationTool(ImplementationTool):
         # if (err_str):
         #     sys.stdout.write(err_str)
         #     return True
-
-        return Status(ImplStatus.SUCCESS)
 
     # def write_to_results_file(self, design, log_path, need_to_run):
 

--- a/bfasst/impl/vivado.py
+++ b/bfasst/impl/vivado.py
@@ -29,9 +29,8 @@ class VivadoImplementationTool(ImplementationTool):
         """Run vivado executable to perform implementation"""
         self.init_design()
 
-        status = self.common_startup(self.check_impl_status)
-        if status:
-            return status
+        if self.up_to_date(self.check_impl_status):
+            return
 
         # Run implementation
         self.run_implementation()

--- a/bfasst/impl/vivado.py
+++ b/bfasst/impl/vivado.py
@@ -41,8 +41,6 @@ class VivadoImplementationTool(ImplementationTool):
         # Update a file in the main directory with info about impl results
         # self.write_to_results_file(design, log_path, need_to_run)
 
-        return self.success_status
-
     def write_header(self, fp):
         fp.write("if { [ catch {\n")
         fp.write("read_edif " + str(self.design.netlist_path) + "\n")

--- a/bfasst/impl/vivado.py
+++ b/bfasst/impl/vivado.py
@@ -5,8 +5,7 @@ import os
 import time
 
 import bfasst
-from bfasst.impl.base import ImplementationTool
-from bfasst.status import Status, ImplStatus
+from bfasst.impl.base import ImplementationTool, ImplementationException
 from bfasst.config import VIVADO_COMMAND
 
 
@@ -35,10 +34,10 @@ class VivadoImplementationTool(ImplementationTool):
             return status
 
         # Run implementation
-        status = self.run_implementation()
+        self.run_implementation()
 
         # Check implementation log
-        status = self.check_impl_status(self.log_path)
+        self.check_impl_status(self.log_path)
 
         # Update a file in the main directory with info about impl results
         # self.write_to_results_file(design, log_path, need_to_run)
@@ -87,9 +86,9 @@ class VivadoImplementationTool(ImplementationTool):
         cmd = VIVADO_COMMAND + ["-source", str(tcl_path)]
         proc = self.exec_and_log(cmd)
         if proc.returncode:
-            return Status(ImplStatus.ERROR)
-
-        return self.success_status
+            raise ImplementationException(
+                f"Implementation failed with return code {proc.returncode}"
+            )
 
     def check_impl_status(self, log_path):
         """Checks the status of Vivado execution for errors"""
@@ -97,18 +96,22 @@ class VivadoImplementationTool(ImplementationTool):
 
         matches = re.search(r"^ERROR:\s*(.*?)$", text, re.M)
         if matches:
-            return Status(ImplStatus.ERROR, matches.group(1).strip())
+            raise ImplementationException("An error occurred: " + matches.group(1).strip())
 
         matches = re.search(
             r"^Design LUT Count \((\d+)\) exceeded Device LUT Count \((\d+)\)$", text, re.M
         )
         if matches:
-            return Status(ImplStatus.TOO_MANY_LUTS, matches.group(1) + "/" + matches.group(2))
+            raise ImplementationException(
+                "Too many luts: " + matches.group(1) + "/" + matches.group(2)
+            )
         matches = re.search(
             r"^Design FF Count \((\d+)\) exceeded Device FF Count \((\d+)\)$", text, re.M
         )
         if matches:
-            return Status(ImplStatus.TOO_MANY_FF, matches.group(1) + "/" + matches.group(2))
+            raise ImplementationException(
+                "Too many FF: " + matches.group(1) + "/" + matches.group(2)
+            )
 
         # Too many I/Os
         matches = re.search(
@@ -120,9 +123,9 @@ class VivadoImplementationTool(ImplementationTool):
             re.M | re.S,
         )
         if matches:
-            return Status(ImplStatus.TOO_MANY_IO, matches.group(2) + "/" + matches.group(1))
-
-        return self.success_status
+            raise ImplementationException(
+                "Too many IO: " + matches.group(2) + "/" + matches.group(1)
+            )
 
     def write_to_results_file(self, log_path, need_to_run):
         """This function writes results to a file.  Not sure if it's used anymore?"""

--- a/bfasst/opt/base.py
+++ b/bfasst/opt/base.py
@@ -5,7 +5,8 @@ from bfasst.status import OptStatus
 from bfasst.tool import Tool
 from bfasst.status import Status
 from bfasst.utils import print_color
-from bfasst.bfasst_exception import BfasstException
+from bfasst.tool import BfasstException
+
 
 class OptException(BfasstException):
     """Base class for all exceptions in the opt package"""

--- a/bfasst/opt/base.py
+++ b/bfasst/opt/base.py
@@ -1,9 +1,7 @@
 """ Base class for logic optimization tools"""
 import abc
-from bfasst.status import OptStatus
 
 from bfasst.tool import Tool
-from bfasst.status import Status
 from bfasst.utils import print_color
 from bfasst.tool import BfasstException
 
@@ -14,8 +12,6 @@ class OptException(BfasstException):
 
 class OptTool(Tool):
     """Base class for logic optimization tools"""
-
-    success_status = Status(OptStatus.SUCCESS)
 
     def __init__(self, cwd, design, flow_args="") -> None:
         super().__init__(cwd, design)

--- a/bfasst/opt/base.py
+++ b/bfasst/opt/base.py
@@ -5,6 +5,10 @@ from bfasst.status import OptStatus
 from bfasst.tool import Tool
 from bfasst.status import Status
 from bfasst.utils import print_color
+from bfasst.bfasst_exception import BfasstException
+
+class OptException(BfasstException):
+    """Base class for all exceptions in the opt package"""
 
 
 class OptTool(Tool):

--- a/bfasst/opt/ic2_base.py
+++ b/bfasst/opt/ic2_base.py
@@ -52,17 +52,14 @@ class Ic2BaseOptTool(OptTool):
             raise e
 
         # Parse synthesis log for errors
-        status = self.check_opt_log(self.log_path)
-        if status.error:
-            return status
+        self.check_opt_log(self.log_path)
 
         # Copy edif netlist out of project directory3
         if not edif_path_temp.is_file():
-            return Status(OptStatus.ERROR)
+            raise OptException("Synthesis failed to produce netlist")
         shutil.copyfile(edif_path_temp, self.design.netlist_path)
 
         # self.write_result_file(design)
-        return Status(OptStatus.SUCCESS)
 
     @abstractmethod
     def run_sythesis(self, prj_path):

--- a/bfasst/opt/ic2_base.py
+++ b/bfasst/opt/ic2_base.py
@@ -8,7 +8,6 @@ import subprocess
 
 import bfasst
 from bfasst.opt.base import OptException, OptTool
-from bfasst.status import OptStatus, Status
 from bfasst.tool import ToolProduct
 
 

--- a/bfasst/opt/ic2_lse.py
+++ b/bfasst/opt/ic2_lse.py
@@ -7,8 +7,8 @@ import in_place
 
 import bfasst
 from bfasst import paths
+from bfasst.opt.base import OptException
 from bfasst.opt.ic2_base import Ic2BaseOptTool
-from bfasst.status import Status, OptStatus
 from bfasst.utils import error
 
 PROJECT_TEMPLATE_FILE = "template_lse.prj"
@@ -62,9 +62,7 @@ class Ic2LseOptTool(Ic2BaseOptTool):
         """check optimization log for errors"""
         text = open(synth_log).read()
         if re.search("^Timeout$", text, re.M):
-            return Status(OptStatus.TIMEOUT)
-
-        return Status(OptStatus.SUCCESS)
+            raise OptException("LSE timed out")
 
     def fix_lut_inits(self):
         """This function goes through the generated netlist and

--- a/bfasst/opt/ic2_synplify.py
+++ b/bfasst/opt/ic2_synplify.py
@@ -7,7 +7,7 @@ import bfasst
 from bfasst import paths
 from bfasst.design import Design
 from bfasst.opt.ic2_base import Ic2BaseOptTool
-from bfasst.status import Status, OptStatus
+from bfasst.opt.base import OptException
 
 PROJECT_TEMPLATE_FILE = "template_sp.prj"
 IC2_SYNPLIFY_PROJ_FILE = "synplify_project.prj"
@@ -75,7 +75,7 @@ class Ic2SynplifyOptTool(Ic2BaseOptTool):
         text = open(synth_log).read()
 
         if re.search("^Timeout$", text, re.M):
-            return Status(OptStatus.TIMEOUT)
+            raise OptException("Synplify timed out")
 
         match = re.search(
             r'Job: "compiler" terminated with error status: \d+\nSee log file: "(.*?)"', text, re.M
@@ -84,8 +84,8 @@ class Ic2SynplifyOptTool(Ic2BaseOptTool):
             text = open(match.group(1)).read()
             match = re.search(r"^@E:\s*(.*?)$", text, re.M)
             if match:
-                return Status(OptStatus.COMPILE_ERROR, match.group(1))
-            return Status(OptStatus.COMPILE_ERROR)
+                raise OptException("Compile error: " + match.group(1))
+            raise OptException("Compile error")
 
         match = re.search(
             r'Job: "fpga_mapper" terminated with error status: \d+\nSee log file: "(.*?)"',
@@ -96,10 +96,8 @@ class Ic2SynplifyOptTool(Ic2BaseOptTool):
             text = open(match.group(1)).read()
             match = re.search(r"^@E:\s*(.*?)$", text, re.M)
             if match:
-                return Status(OptStatus.MAPPER_ERROR, match.group(1))
-            return Status(OptStatus.MAPPER_ERROR)
-
-        return Status(OptStatus.SUCCESS)
+                raise OptException("A mapper error occurred: " + match.group(1))
+            raise OptException("A mapper error occurred")
 
     # def write_result_file(self, design):
     #     if design.results_summary_path is None:

--- a/bfasst/reverse_bit/base.py
+++ b/bfasst/reverse_bit/base.py
@@ -4,7 +4,8 @@ import abc
 from bfasst.tool import Tool
 from bfasst.utils import print_color
 from bfasst.status import Status, BitReverseStatus
-from bfasst.bfasst_exception import BfasstException
+from bfasst.tool import BfasstException
+
 
 class ReverseBitException(BfasstException):
     """Base class for all exceptions in the reverse_bit package"""

--- a/bfasst/reverse_bit/base.py
+++ b/bfasst/reverse_bit/base.py
@@ -3,7 +3,6 @@ import abc
 
 from bfasst.tool import Tool
 from bfasst.utils import print_color
-from bfasst.status import Status, BitReverseStatus
 from bfasst.tool import BfasstException
 
 
@@ -13,8 +12,6 @@ class ReverseBitException(BfasstException):
 
 class ReverseBitTool(Tool):
     """Base class for bitstream to netlist tools"""
-
-    success_status = Status(BitReverseStatus.SUCCESS)
 
     def __init__(self, cwd, design, flow_args="") -> None:
         super().__init__(cwd, design)

--- a/bfasst/reverse_bit/base.py
+++ b/bfasst/reverse_bit/base.py
@@ -4,6 +4,10 @@ import abc
 from bfasst.tool import Tool
 from bfasst.utils import print_color
 from bfasst.status import Status, BitReverseStatus
+from bfasst.bfasst_exception import BfasstException
+
+class ReverseBitException(BfasstException):
+    """Base class for all exceptions in the reverse_bit package"""
 
 
 class ReverseBitTool(Tool):

--- a/bfasst/reverse_bit/icestorm.py
+++ b/bfasst/reverse_bit/icestorm.py
@@ -5,8 +5,7 @@ import time
 import os
 
 import bfasst
-from bfasst.reverse_bit.base import ReverseBitTool
-from bfasst.status import Status, BitReverseStatus
+from bfasst.reverse_bit.base import ReverseBitTool, ReverseBitException
 
 # PROJECT_TEMPLATE_FILE = 'template_lse.prj'
 # IC2_LSE_PROJ_FILE = 'lse_project.prj'
@@ -43,16 +42,14 @@ class IcestormReverseBitTool(ReverseBitTool):
             self.fix_pcf_names()
             # Bitstream to ascii file
             asc_path = self.work_dir / (self.design.top + ".asc")
-            status = self.convert_bit_to_asc(self.design.bitstream_path, asc_path)
+            self.convert_bit_to_asc(self.design.bitstream_path, asc_path)
 
             # Ascii to netlist
-            status = self.convert_asc_to_netlist(
+            self.convert_asc_to_netlist(
                 asc_path, self.design.constraints_path, self.design.reversed_netlist_path
             )
 
         self.write_to_results_file(self.design.reversed_netlist_path, need_to_run)
-
-        return status
 
     def convert_bit_to_asc(self, bitstream_path, asc_path):
         cmd = [bfasst.config.ICESTORM_INSTALL_DIR / "icepack" / "iceunpack", bitstream_path]
@@ -61,9 +58,7 @@ class IcestormReverseBitTool(ReverseBitTool):
             process = subprocess.run(cmd, stdout=fp, stderr=subprocess.STDOUT, cwd=self.work_dir)
 
             if process.returncode:
-                return Status(BitReverseStatus.ERROR)
-
-        return Status(BitReverseStatus.SUCCESS)
+                raise ReverseBitException("Error converting bitstream to ASCII file.")
 
     def convert_asc_to_netlist(self, asc_path, constraints_path, netlist_path):
         """Converts an ASC file to a netlist using IceStorm tools."""
@@ -79,9 +74,7 @@ class IcestormReverseBitTool(ReverseBitTool):
             process = subprocess.run(cmd, stdout=fp, stderr=subprocess.STDOUT, cwd=self.work_dir)
 
             if process.returncode:
-                return Status(BitReverseStatus.ERROR)
-
-        return Status(BitReverseStatus.SUCCESS)
+                raise ReverseBitException("Error converting ASC file to netlist.")
 
     # TODO: Ideally, this function should probably check against the top-level
     #       I/O on the original RTL to make sure that none of the signals have

--- a/bfasst/reverse_bit/xray.py
+++ b/bfasst/reverse_bit/xray.py
@@ -49,16 +49,14 @@ class XRayReverseBitTool(ReverseBitTool):
                 self.design.top + "_" + self.design.cur_error_flow_name + "_reversed.v"
             )
 
-        status = self.get_prev_run_status(
+        if not self.need_to_rerun(
             [generate_fasm, generate_netlist],
             dependency_modified_time=max(
                 pathlib.Path(__file__).stat().st_mtime, self.design.bitstream_path.stat().st_mtime
             ),
-        )
-
-        if status is not None:
+        ):
             self.print_skipping_reverse_bit()
-            return status
+            return
 
         self.print_running_reverse_bit()
         self.open_new_log()
@@ -78,7 +76,7 @@ class XRayReverseBitTool(ReverseBitTool):
                 self.to_netlist_log_parser(self.to_netlist_log)
             raise e
 
-        return self.to_netlist_log_parser(self.to_netlist_log)
+        self.to_netlist_log_parser(self.to_netlist_log)
 
     def convert_bit_to_fasm(self, bitstream_path, fasm_path):
         """Convert bitstream to FASM file"""

--- a/bfasst/reverse_bit/xray.py
+++ b/bfasst/reverse_bit/xray.py
@@ -3,8 +3,7 @@ import os
 import re
 import pathlib
 
-from bfasst.reverse_bit.base import ReverseBitTool
-from bfasst.status import BfasstException, Status, BitReverseStatus
+from bfasst.reverse_bit.base import ReverseBitTool, ReverseBitException
 from bfasst import paths, config
 from bfasst.tool import ToolProduct
 
@@ -65,15 +64,15 @@ class XRayReverseBitTool(ReverseBitTool):
         self.open_new_log()
 
         # Bitstream to fasm file
-        status = self.convert_bit_to_fasm(self.design.bitstream_path, fasm_path)
+        self.convert_bit_to_fasm(self.design.bitstream_path, fasm_path)
 
         # fasm to netlist
         xdc_path = self.work_dir / (self.design.top + "_reversed.xdc")
         try:
-            status = self.convert_fasm_to_netlist(
+            self.convert_fasm_to_netlist(
                 fasm_path, self.design.constraints_path, self.design.reversed_netlist_path, xdc_path
             )
-        except BfasstException as e:
+        except ReverseBitException as e:
             # See if the log parser can find an error message
             if self.to_netlist_log.is_file():
                 self.to_netlist_log_parser(self.to_netlist_log)
@@ -103,9 +102,7 @@ class XRayReverseBitTool(ReverseBitTool):
         with open(fasm_path, "w") as fp, open(self.to_fasm_log, "w") as fp_err:
             proc = self.exec_and_log(cmd, fp=fp, fp_err=fp_err, env=my_env)
             if proc.returncode:
-                return Status(BitReverseStatus.ERROR)
-
-        return Status(BitReverseStatus.SUCCESS)
+                raise ReverseBitException("Failed to convert bitstream to FASM file")
 
     def convert_fasm_to_netlist(self, fasm_path, constraints_path, netlist_path, xdc_path):
         """Convert the FASM file to a netlist"""
@@ -134,9 +131,7 @@ class XRayReverseBitTool(ReverseBitTool):
         with open(self.to_netlist_log, "w") as fp:
             proc = self.exec_and_log(cmd, fp=fp, cwd=self.fasm2bels_path)
         if proc.returncode:
-            return Status(BitReverseStatus.ERROR)
-
-        return Status(BitReverseStatus.SUCCESS)
+            raise ReverseBitException("Failed to convert FASM to netlist")
 
     def to_netlist_log_parser(self, log_path):
         """Parse the 'To netlist' log file for errors"""
@@ -144,14 +139,15 @@ class XRayReverseBitTool(ReverseBitTool):
 
         matches = re.search(r"^\s*(assert .*?)$", text, re.M)
         if matches:
-            return Status(BitReverseStatus.ERROR, matches.group(1).strip())
+            raise ReverseBitException(
+                "FASM to netlist assertion failed: " + matches.group(1).strip()
+            )
 
         matches = re.search(r"^\s*KeyError: '(DSP_[LR])'\s*$", text, re.M)
         if matches:
-            return Status(BitReverseStatus.UNSUPPORTED_PRIMITVE, matches.group(1).strip())
+            raise ReverseBitException("Unsupported Primitive: " + matches.group(1).strip())
 
         # KeyError: 'DSP_L'
-        return Status(BitReverseStatus.SUCCESS)
 
     # def write_to_results_file(self, design, netlist_path, need_to_run):
     #     raise NotImplementedError

--- a/bfasst/status.py
+++ b/bfasst/status.py
@@ -96,30 +96,13 @@ msg_map = {
 }
 
 
-class BfasstException(Exception):
-    # The creator is the object that raised the exception
-    # If the creator is not none, then the exception was raised from a bfasst
-    # status object
-    def __init__(self, err, msg, creator=None):
-        super().__init__(msg)
-        self.error = err
-        self.msg = msg
-        self.creator = creator
-
-
 class Status:
     """Represents the status of a BFASST tool after it has run"""
 
-    def __init__(self, status, msg="", raise_excep=True):
+    def __init__(self, status, msg=""):
         self.status = status
         self.msg = msg if msg else ""
         self.error = bool(status.value)
-        if status.value and raise_excep:
-            # If the msg exists and is not in the msg_map, then it is a custom message
-            # and should be included in the exception
-            if msg and msg not in msg_map[self.status]:
-                raise BfasstException(status, f"{msg_map[self.status]}: {self.msg}", self)
-            raise BfasstException(status, msg_map[self.status], self)
 
     def __str__(self):
         # If the msg exists and is not in the msg_map, then it is a custom message

--- a/bfasst/synth/base.py
+++ b/bfasst/synth/base.py
@@ -4,6 +4,11 @@ import abc
 from bfasst import tool
 from bfasst.utils import print_color
 from bfasst.status import SynthStatus, Status
+from bfasst.bfasst_exception import BfasstException
+
+
+class SynthesisException(BfasstException):
+    """Base class for all exceptions in the synth package"""
 
 
 class SynthesisTool(tool.Tool):

--- a/bfasst/synth/base.py
+++ b/bfasst/synth/base.py
@@ -3,7 +3,6 @@ import abc
 
 from bfasst import tool
 from bfasst.utils import print_color
-from bfasst.status import SynthStatus, Status
 from bfasst.tool import BfasstException
 
 
@@ -13,8 +12,6 @@ class SynthesisException(BfasstException):
 
 class SynthesisTool(tool.Tool):
     """Base synthesis tool class"""
-
-    success_status = Status(SynthStatus.SUCCESS)
 
     def __init__(self, cwd, design, flow_args="") -> None:
         super().__init__(cwd, design)

--- a/bfasst/synth/base.py
+++ b/bfasst/synth/base.py
@@ -4,7 +4,7 @@ import abc
 from bfasst import tool
 from bfasst.utils import print_color
 from bfasst.status import SynthStatus, Status
-from bfasst.bfasst_exception import BfasstException
+from bfasst.tool import BfasstException
 
 
 class SynthesisException(BfasstException):

--- a/bfasst/synth/ic2_base.py
+++ b/bfasst/synth/ic2_base.py
@@ -27,11 +27,9 @@ class Ic2BaseSynthesisTool(SynthesisTool):
         lib_files = self.design.vhdl_libs.items()
 
         # call the lse optimizer
-        status = self.opt_tool.create_netlist(
+        self.opt_tool.create_netlist(
             self.design, design_files, lib_files, force_run=force_new_opt_run
         )
-
-        return status
 
     @abstractmethod
     def get_tool(self):

--- a/bfasst/synth/vivado.py
+++ b/bfasst/synth/vivado.py
@@ -5,9 +5,8 @@ import pathlib
 
 import bfasst
 from bfasst.design import HdlType
-from bfasst.synth.base import SynthesisTool
+from bfasst.synth.base import SynthesisTool, SynthesisException
 from bfasst.synth import vivado_ioparse
-from bfasst.status import Status, SynthStatus
 from bfasst.config import VIVADO_COMMAND
 from bfasst.tool import ToolProduct
 
@@ -152,15 +151,11 @@ class VivadoSynthesisTool(SynthesisTool):
         cmd = VIVADO_COMMAND + ["-source", str(tcl_path)]
         proc = self.exec_and_log(cmd)
         if proc.returncode:
-            return Status(SynthStatus.ERROR)
-
-        return self.success_status
+            raise SynthesisException(f"Vivado synthesis failed with return code {proc.returncode}")
 
     def check_synth_log(self, log_path):
         text = open(log_path).read()
 
         match = re.search(r"^ERROR:\s*(.*?)$", text, re.M)
         if match:
-            return Status(SynthStatus.ERROR, match.group(1).strip())
-
-        return self.success_status
+            raise SynthesisException(f"Vivado synthesis failed with error: {match.group(1)}")

--- a/bfasst/synth/vivado.py
+++ b/bfasst/synth/vivado.py
@@ -35,7 +35,7 @@ class VivadoSynthesisTool(SynthesisTool):
 
     TOOL_WORK_DIR = "vivado_synth"
 
-    def check_runs(self):
+    def up_to_date(self):
         """Check if synthesis has already been run"""
 
         # Save edif netlist path to design object
@@ -51,7 +51,7 @@ class VivadoSynthesisTool(SynthesisTool):
             generate_constraints = ToolProduct(self.design.constraints_path)
             tool_products = [generate_netlist, generate_constraints]
 
-        return self.get_prev_run_status(
+        return not self.need_to_rerun(
             tool_products,
             dependency_modified_time=max(
                 pathlib.Path(__file__).stat().st_mtime, self.design.last_modified_time()
@@ -61,10 +61,8 @@ class VivadoSynthesisTool(SynthesisTool):
     def create_netlist(self):
         """create netlist from design"""
 
-        status = self.check_runs()
-        if status is not None:
+        if self.up_to_date():
             self.print_skipping_synth()
-            return status
 
         # Run synthesis flow
         self.print_running_synth()
@@ -80,7 +78,7 @@ class VivadoSynthesisTool(SynthesisTool):
             extract_contraints(self.design, report_io_path)
 
         # Check synthesis log
-        return self.check_synth_log(self.log_path)
+        self.check_synth_log(self.log_path)
 
     def write_header(self, stream):
         stream.write("if { [ catch {\n")

--- a/bfasst/synth/yosys.py
+++ b/bfasst/synth/yosys.py
@@ -8,8 +8,7 @@ import time
 
 import bfasst
 from bfasst import paths
-from bfasst.synth.base import SynthesisTool
-from bfasst.status import Status, SynthStatus
+from bfasst.synth.base import SynthesisException, SynthesisTool
 
 YOSYS_SCRIPT_TEMPLATE = "ex_yos_tech.yos"
 YOSYS_SCRIPT_FILE = "script.yos"
@@ -47,14 +46,13 @@ class YosysTechSynthTool(SynthesisTool):
 
         try:
             proc = self.exec_and_log(cmd, timeout=bfasst.config.YOSYS_TIMEOUT)
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
             # TODO: Write to logs here
-            return Status(SynthStatus.TIMEOUT)
+            raise SynthesisException("Yosys synthesis timed out") from e
         if proc.returncode != 0:
-            return Status(SynthStatus.ERROR)
+            raise SynthesisException(f"Yosys synthesis failed with return code {proc.returncode}")
 
         self.write_to_results_file(log_path)
-        return Status(SynthStatus.SUCCESS)
 
     def create_yosys_script(self, netlist_path):
         """Create the yosys script that generates the netlist"""
@@ -79,12 +77,12 @@ class YosysTechSynthTool(SynthesisTool):
                 "-v" + str(netlist_path),
             ]
             proc = self.exec_and_log(cmd, timeout=bfasst.config.I2C_LSE_TIMEOUT)
-        except subprocess.TimeoutExpired:
-            return Status(SynthStatus.TIMEOUT)
+        except subprocess.TimeoutExpired as e:
+            raise SynthesisException("Yosys script generation timed out") from e
         if proc.returncode != 0:
-            return Status(SynthStatus.ERROR)
-
-        return Status(SynthStatus.SUCCESS)
+            raise SynthesisException(
+                f"Yosys script generation failed with return code {proc.returncode}"
+            )
 
     def write_to_results_file(self, log_path):
         """Write the results of the run to the log"""

--- a/bfasst/tool.py
+++ b/bfasst/tool.py
@@ -62,12 +62,6 @@ class Tool(abc.ABC):
         """The subdirectory in the build folder to used for this tool."""
         raise NotImplementedError
 
-    @property
-    @classmethod
-    @abc.abstractclassmethod
-    def success_status(self):
-        raise NotImplementedError
-
     def remove_logs(self):
         """
         Iterate over the log files that already exist in the work directory and remove them.
@@ -127,9 +121,8 @@ class Tool(abc.ABC):
         self.log_fp.write(text + "\n")
         self.log_fp.flush()
 
-    def get_prev_run_status(self, tool_products, dependency_modified_time):
-        """Determines whether previous run data can be reused, and if so,
-        returns the Status, otherwise returns None if Tool needs to be re-run"""
+    def need_to_rerun(self, tool_products, dependency_modified_time):
+        """Determines whether previous run data can be reused or if the tool needs to be rerun."""
 
         # Loop through tool prodcuts
         for tool_product in tool_products:
@@ -137,20 +130,20 @@ class Tool(abc.ABC):
             if tool_product.log_path:
                 # If log file is missing, re-run
                 if not tool_product.log_path.is_file():
-                    return None
+                    return True
 
                 # If log file is out of date, need to re-run
                 if dependency_modified_time > tool_product.log_path.stat().st_mtime:
-                    return None
+                    return True
 
-                # If log file has an error, return that status
+                # If log file has an error, raise an exception
                 status = tool_product.check_log_fcn(tool_product.log_path)
                 if status.error:
-                    return status
+                    raise BfasstException(f"Previous run of tool had an error: {status.msg}")
 
                 # If log file doesn't have an error, but output file is expected and missing, re-run
                 if (tool_product.file_path is not None) and (not tool_product.file_path.is_file()):
-                    return None
+                    return True
             else:
                 # This ToolProduct doesn't produce a log file
 
@@ -158,9 +151,10 @@ class Tool(abc.ABC):
                 if not tool_product.file_path.is_file() or (
                     dependency_modified_time > tool_product.file_path.stat().st_mtime
                 ):
-                    return None
+                    return True
 
-        return self.success_status
+        # Tool does not need to be rerun
+        return False
 
     def exec_and_log(self, cmd, cwd=None, fp=None, fp_err=None, env=None, timeout=None):
         """Run a command using Popen and log the output, return the process handle"""

--- a/bfasst/tool.py
+++ b/bfasst/tool.py
@@ -13,6 +13,10 @@ from dataclasses import dataclass
 from bfasst.utils import TermColor, print_color
 
 
+class BfasstException(Exception):
+    """Base class for all tool exceptions in the bfasst package."""
+
+
 @dataclass
 class ToolProduct:
     """A file product of any tool.  If the tool producesd a log file, then you can also provide

--- a/bfasst/transform/base.py
+++ b/bfasst/transform/base.py
@@ -1,7 +1,7 @@
 """ This is use to perform some transformation on a design file(s)"""
 
 from bfasst import tool
-from bfasst.bfasst_exception import BfasstException
+from bfasst.tool import BfasstException
 
 
 class TransformException(BfasstException):

--- a/bfasst/transform/base.py
+++ b/bfasst/transform/base.py
@@ -1,6 +1,11 @@
 """ This is use to perform some transformation on a design file(s)"""
 
 from bfasst import tool
+from bfasst.bfasst_exception import BfasstException
+
+
+class TransformException(BfasstException):
+    """Base class for all exceptions in the transform package"""
 
 
 class TransformTool(tool.Tool):

--- a/bfasst/transform/error_injector.py
+++ b/bfasst/transform/error_injector.py
@@ -2,8 +2,7 @@
 from enum import Enum
 from random import randrange, sample
 import spydrnet as sdn
-from bfasst.transform.base import TransformTool
-from bfasst.status import Status, TransformStatus
+from bfasst.transform.base import TransformTool, TransformException
 from bfasst.utils import convert_verilog_literal_to_int
 from bfasst.vendor_utils.xilinx import get_unisim_cell_inputs_and_outputs
 
@@ -18,7 +17,6 @@ class ErrorType(Enum):
 class ErrorInjector(TransformTool):
     """Tool to inject errors into a netlist"""
 
-    success_status = Status(TransformStatus.SUCCESS)
     TOOL_WORK_DIR = "error_injection"
 
     def __init__(self, cwd, design) -> None:
@@ -51,8 +49,7 @@ class ErrorInjector(TransformTool):
         elif error_type == ErrorType.WIRE_SWAP:
             self.__inject_wire_swap()
         else:
-            return Status(TransformStatus.ERROR, "Invalid error type")
-        return Status(TransformStatus.SUCCESS)
+            raise TransformException("Invalid error type")
 
     def __inject_bit_flip(self):
         """Injects a bit flip error into the netlist"""

--- a/bfasst/transform/xilinx_phys_netlist.py
+++ b/bfasst/transform/xilinx_phys_netlist.py
@@ -117,7 +117,7 @@ class XilinxPhysNetlist(TransformTool):
         System.setOut(PrintStream(File(str(self.work_dir / "rapidwright_stdout.log"))))
 
         # Check for up to date previous run
-        status = self.get_prev_run_status(
+        if not self.need_to_rerun(
             tool_products=[
                 ToolProduct(phys_netlist_verilog_path),
             ],
@@ -126,10 +126,9 @@ class XilinxPhysNetlist(TransformTool):
                 self.design.xilinx_impl_checkpoint_path.stat().st_mtime,
                 self.design.impl_edif_path.stat().st_mtime,
             ),
-        )
-
-        if status is not None:
+        ):
             print_color(self.TERM_COLOR_STAGE, "Physical Netlist conversion already run")
+            return
 
         self.open_new_log()
         self.log_color(


### PR DESCRIPTION
- Got rid of exceptions raised by status and moved exceptions to separate file
- Added base inheritor of bfasst exception
- Updated location of bfasst exception to tool.py
- Changed conformal compare tool to raise exceptions instead of return error statuses
- Changed onespin compare tool to no longer return status
- Changed waveform compare tool to raise exceptions instead of return error statuses
- Changed yosys compare tool to raise exceptions instead of return error statuses
- Removed statuses from old error injector
- removed statuses from ic2 impl
- removed statuses from vivado impl
- removed statuses from ic2 opt inheritors
- removed statuses from icestorm rev bit tool
- removed hard-coded status returns from xray rev tool
- removed hard-coded status returns from vivado synth tool
- removed hard-coded status returns from vivado synth tool
- removed statuses from new error injector
- removed hard-coded status returns from xilinx phys netlist tool
- removed statuses from structural compare tool
- changed KeyError to CompareException
- changed how base compare tool handles up to date comparisons
- all inheritors of base compare tool return if the comparison is up to date
- changed how impl base class checks if implementation is up to date
- inheritors of impl base class return if implementation is up to date
- Updated ic2 base class to remove status returns
- Updated ic2 base class to remove status returns
- fixed pylint errors
- removed statuses from reverse bit base tool
- updated how need to rerun is checked
- removed statuses from base synth tool
- removed status references from ic2 base tool
- changed how need to rerun is checked
- changed how need to rerun is checked
- changed how need to rerun is checked
