### PR TITLE
Catch AssertionError and convert to status

### DIFF
--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import signal
 import sys
+import traceback
 import threading
 import time
 import concurrent.futures
@@ -149,6 +150,9 @@ def run_job(print_lock, running_list, job, statuses, experiment, jobs):
         status = ""
     except BfasstException as e:
         status = f"{type(e).__name__}: {e}\n"
+    except AssertionError as e:
+        formatted_lines = traceback.format_exc().splitlines()
+        status = f"AssertionErrror: {formatted_lines[-3]}"
 
     # print the job status
     print_job_status(experiment, print_lock, statuses, job, status)

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -150,7 +150,7 @@ def run_job(print_lock, running_list, job, statuses, experiment, jobs):
         status = ""
     except BfasstException as e:
         status = f"{type(e).__name__}: {e}\n"
-    except AssertionError as e:
+    except AssertionError:
         formatted_lines = traceback.format_exc().splitlines()
         status = f"AssertionErrror: {formatted_lines[-3]}"
 


### PR DESCRIPTION
Would be nice if run_experiment did not totally fail on an assertion error. Now it captures that as a status, so you can then investigate why that particular design failed.