### PR TITLE
Hdl keyword I/O error fix

### DIFF
--- a/bfasst/compare/structural.py
+++ b/bfasst/compare/structural.py
@@ -159,7 +159,9 @@ class StructuralCompareTool(CompareTool):
                     self.reversed_netlist.get_pin(pin.name, pin.index).net,
                 )
             except KeyError as e:
-                raise CompareException(f"KeyError during port mapping {pin.name} {pin.index}, is a top level I/O a reserved HDL keyword?") from e
+                raise CompareException(
+                    f"KeyError during port mapping {pin.name} {pin.index}, is a top level I/O a reserved HDL keyword?"
+                ) from e
 
         self.log_title("Starting mapping iterations")
         progress = True

--- a/bfasst/compare/structural.py
+++ b/bfasst/compare/structural.py
@@ -153,10 +153,13 @@ class StructuralCompareTool(CompareTool):
                 f"{pin.name}[{pin.index}] to",
                 f"{pin.name}[{pin.index}]",
             )
-            self.add_net_mapping(
-                pin.net,
-                self.reversed_netlist.get_pin(pin.name, pin.index).net,
-            )
+            try:
+                self.add_net_mapping(
+                    pin.net,
+                    self.reversed_netlist.get_pin(pin.name, pin.index).net,
+                )
+            except KeyError as e:
+                raise CompareException(f"KeyError during port mapping {pin.name} {pin.index}, is a top level I/O a reserved HDL keyword?") from e
 
         self.log_title("Starting mapping iterations")
         progress = True

--- a/bfasst/compare/structural.py
+++ b/bfasst/compare/structural.py
@@ -160,7 +160,8 @@ class StructuralCompareTool(CompareTool):
                 )
             except KeyError as e:
                 raise CompareException(
-                    f"KeyError during port mapping {pin.name} {pin.index}, is a top level I/O a reserved HDL keyword?"
+                    f"KeyError during port mapping {pin.name}, "
+                    + "is a top level I/O a reserved HDL keyword?"
                 ) from e
 
         self.log_title("Starting mapping iterations")

--- a/bfasst/compare/structural.py
+++ b/bfasst/compare/structural.py
@@ -160,8 +160,8 @@ class StructuralCompareTool(CompareTool):
                 )
             except KeyError as e:
                 raise CompareException(
-                    f"KeyError during port mapping {pin.name}, "
-                    + "is a top level I/O a reserved HDL keyword?"
+                    f"KeyError during port mapping, is the I/O {pin.name} "
+                    + "signal a reserved HDL keyword?"
                 ) from e
 
         self.log_title("Starting mapping iterations")

--- a/designs/ooc/graphiti/graphiti.vhd
+++ b/designs/ooc/graphiti/graphiti.vhd
@@ -17,7 +17,7 @@ entity graphiti is
 		clk : in std_logic;
 		clk15M : in std_logic;
 		reset : in std_logic;
-		output : out std_logic_vector (15 downto 0);
+		out_put : out std_logic_vector (15 downto 0);
 		in_r : in std_logic_vector (4 downto 0);
 		in_g : in std_logic_vector (4 downto 0);
 		in_b : in std_logic_vector (4 downto 0);
@@ -130,7 +130,7 @@ signal modvs : signed(28 downto 0);
 signal modys : signed(28 downto 0);
 
 
--- workaround für xilinx
+-- workaround fï¿½r xilinx
 signal input_fir1 : std_logic_vector (11 downto 0);
 signal input_fir2 : std_logic_vector (11 downto 0);
 signal input_delay : std_logic_vector (11 downto 0);
@@ -275,7 +275,7 @@ variable i_output : signed (16 downto 0);
 begin
 
 	if reset='0' then
-	   output <= (others => '0');
+	   out_put <= (others => '0');
 	elsif clk'event and clk='1' then
 		if tmr_phase='1' then
 			psin := -sin_data;
@@ -310,7 +310,7 @@ begin
 				i_output := conv_signed(14563,17) + prevideo;
 		end if;
 		
-		output <= conv_std_logic_vector (i_output (15 downto 0),16);
+		out_put <= conv_std_logic_vector (i_output (15 downto 0),16);
 		
 	end if;
 end process;


### PR DESCRIPTION
fixed design that used hdl keyword I/Os, added warning to mapping to prevent future designs from doing the same