### PR TITLE
Update ninja tools to handle relative paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ packages:
 		libboost-filesystem-dev \
 		libboost-python-dev \
 		libboost-system-dev \
-		libc++-dev
+		libc++-dev \
 		libcapnp-dev \
 		libffi-dev \
 		libncurses5 \

--- a/bfasst/compare/waveform.py
+++ b/bfasst/compare/waveform.py
@@ -1,4 +1,5 @@
 """Waveform equivalence checker. Uses WaFoVe for verification."""
+# pylint: skip-file
 
 import re
 

--- a/bfasst/ninja_flows/flow.py
+++ b/bfasst/ninja_flows/flow.py
@@ -2,10 +2,15 @@
 import abc
 
 from bfasst.ninja_tools.vivado.vivado import Vivado
+from bfasst.paths import BUILD_DIR, DESIGNS_PATH
 
 
 class Flow(abc.ABC):
     """Base class for all ninja flows"""
+
+    def __init__(self, design_path):
+        self.design_path = design_path
+        self.design_build_path = BUILD_DIR / design_path.relative_to(DESIGNS_PATH)
 
     @abc.abstractmethod
     def create_rule_snippets(self):

--- a/bfasst/ninja_flows/ninja_flow_manager.py
+++ b/bfasst/ninja_flows/ninja_flow_manager.py
@@ -1,9 +1,13 @@
 """Utility to manage the creation and execution of ninja flows."""
-from argparse import ArgumentParser
+import argparse
 import json
+import pathlib
+
 import chevron
+
 from bfasst.ninja_flows.flow_utils import create_build_file, get_flow
 from bfasst.paths import DESIGNS_PATH, NINJA_BUILD_PATH, NINJA_FLOWS_PATH, ROOT_PATH
+from bfasst.utils import error
 
 
 class NinjaFlowManager:
@@ -29,10 +33,21 @@ class NinjaFlowManager:
         """Create the ninja flows for the given designs."""
         self.flow_name = flow_name
         self.flows = []
-        self.designs = designs
+        self.designs = []
         self.flow_args = flow_args
+
+        # Get absolute design paths.  First check if a path to the design was provided,
+        # and if not, look for it in the designs directory.
         for design in designs:
-            flow = get_flow(flow_name)(design, flow_args)
+            design_path = pathlib.Path(design).resolve()
+            if not (design_path.is_dir() and design_path.is_relative_to(DESIGNS_PATH)):
+                design_path = DESIGNS_PATH / design
+            if not design_path.is_dir():
+                error(f"Design {design} cannot be found.  This must be a subdirectory of designs/")
+
+            self.designs.append(design_path)
+
+            flow = get_flow(flow_name)(design_path, flow_args)
             self.flows.append(flow)
 
     def run_flows(self):
@@ -53,7 +68,6 @@ class NinjaFlowManager:
             f.write(master_ninja)
 
     def __populate_template(self):
-        self.__get_absolute_design_paths()
         with open(ROOT_PATH / "master.ninja.mustache", "r") as f:
             master_ninja = chevron.render(
                 f,
@@ -68,16 +82,13 @@ class NinjaFlowManager:
 
         return master_ninja
 
-    def __get_absolute_design_paths(self):
-        self.designs = [str(DESIGNS_PATH / design) for design in self.designs]
-
 
 def get_design_basenames(designs):
     return [("/").join(design.split("/")[-2:]) for design in designs]
 
 
 if __name__ == "__main__":
-    parser = ArgumentParser()
+    parser = argparse.ArgumentParser()
     parser.add_argument("--flow", type=str, required=True, help="Name of the flow to run")
     parser.add_argument("--flow_args", type=str, help="Additional cmd line arguments for the flow")
     parser.add_argument("--designs", required=True, nargs="+", help="Designs to run the flow on")

--- a/bfasst/ninja_flows/vivado.py
+++ b/bfasst/ninja_flows/vivado.py
@@ -7,7 +7,7 @@ class Vivado(Flow):
     """Flow to create Vivado synthesis and implementation ninja snippets."""
 
     def __init__(self, design, flow_args=None, ooc=False):
-        super().__init__()
+        super().__init__(design)
         self.ooc = ooc
         self.vivado_tool = self.configure_vivado_tool(design, flow_args, ooc)
 

--- a/bfasst/ninja_flows/vivado_and_reversed.py
+++ b/bfasst/ninja_flows/vivado_and_reversed.py
@@ -8,7 +8,7 @@ class VivadoAndReversed(Flow):
     """Flow to reverse a netlist from a bitstream using xray."""
 
     def __init__(self, design, flow_args=None):
-        super().__init__()
+        super().__init__(design)
         self.vivado_tool = self.configure_vivado_tool(design, flow_args)
         self.xrev_tool = XrevTool(design)
 

--- a/bfasst/ninja_flows/vivado_conformal.py
+++ b/bfasst/ninja_flows/vivado_conformal.py
@@ -11,7 +11,7 @@ class VivadoConformal(Flow):
     """Run vivado, phys_netlist, reverse with xray, then compare with conformal."""
 
     def __init__(self, design, flow_args=None):
-        super().__init__()
+        super().__init__(design)
         self.vivado_tool = self.configure_vivado_tool(design, flow_args)
         self.xrev_tool = Xray(design)
         self.conformal_tool = Conformal(design)

--- a/bfasst/ninja_flows/vivado_phys_netlist.py
+++ b/bfasst/ninja_flows/vivado_phys_netlist.py
@@ -9,7 +9,7 @@ class VivadoPhysNetlist(Flow):
     """Creates a Vivado netlist that has only physical primitives."""
 
     def __init__(self, design, flow_args=None):
-        super().__init__()
+        super().__init__(design)
         self.vivado_tool = self.configure_vivado_tool(design, flow_args)
         self.phys_netlist_tool = PhysNetlist(design)
 

--- a/bfasst/ninja_flows/vivado_phys_netlist_cmp.py
+++ b/bfasst/ninja_flows/vivado_phys_netlist_cmp.py
@@ -11,7 +11,7 @@ class VivadoPhysNetlistCmp(Flow):
     """Structural Comparison of physical netlist and reversed netlist"""
 
     def __init__(self, design, flow_args=None):
-        super().__init__()
+        super().__init__(design)
         self.vivado_tool = self.configure_vivado_tool(design, flow_args)
         self.phys_netlist_tool = PhysNetlist(design)
         self.xray_tool = Xray(design)

--- a/bfasst/ninja_flows/vivado_phys_netlist_xrev.py
+++ b/bfasst/ninja_flows/vivado_phys_netlist_xrev.py
@@ -11,7 +11,7 @@ class VivadoPhysNetlistXrev(Flow):
     """Flow that combines vivado phys netlist and xray/f2b reversal."""
 
     def __init__(self, design, flow_args=None):
-        super().__init__()
+        super().__init__(design)
         self.vivado_tool = self.configure_vivado_tool(design, flow_args)
         self.phys_netlist_tool = PhysNetlist(design)
         self.xrev_tool = Xray(design)

--- a/bfasst/ninja_flows/vivado_structural_error_injection.py
+++ b/bfasst/ninja_flows/vivado_structural_error_injection.py
@@ -7,10 +7,7 @@ from bfasst.ninja_tools.compare.structural.structural import Structural
 from bfasst.ninja_tools.rev_bit.xray import Xray
 from bfasst.ninja_tools.transform.error_injector import ErrorInjector
 from bfasst.ninja_tools.transform.phys_netlist import PhysNetlist
-from bfasst.paths import (
-    BUILD_DIR,
-    NINJA_FLOWS_PATH,
-)
+from bfasst.paths import NINJA_FLOWS_PATH
 
 from bfasst.ninja_utils.error_injector import ErrorType
 
@@ -19,7 +16,7 @@ class VivadoStructuralErrorInjection(Flow):
     """Inject an error into a xrev netlist and run a structural compare to detect it."""
 
     def __init__(self, design, flow_args=None):
-        super().__init__()
+        super().__init__(design)
         random.seed(0)
         self.vivado_tool = self.configure_vivado_tool(design, flow_args)
         self.phys_netlist_tool = PhysNetlist(design)
@@ -27,7 +24,7 @@ class VivadoStructuralErrorInjection(Flow):
         self.error_injector_tool = ErrorInjector(design)
         self.compare_tool = Structural(design)
 
-        self.error_injector_build = BUILD_DIR / design / "error_injection"
+        self.error_injector_build = self.design_build_path / "error_injection"
 
     def create_rule_snippets(self):
         """Create the rule snippets for the flow and append them to build.ninja."""

--- a/bfasst/ninja_flows/vivado_yosys_impl.py
+++ b/bfasst/ninja_flows/vivado_yosys_impl.py
@@ -9,7 +9,7 @@ class VivadoYosysImpl(Flow):
     """Flow to compare reversed netlist to original using yosys."""
 
     def __init__(self, design, flow_args=None):
-        super().__init__()
+        super().__init__(design)
         self.vivado_tool = self.configure_vivado_tool(design, flow_args)
         self.xrev_tool = Xray(design)
         self.yosys_tool = Yosys(design)

--- a/bfasst/ninja_tools/compare/conformal/conformal.py
+++ b/bfasst/ninja_tools/compare/conformal/conformal.py
@@ -10,7 +10,7 @@ class Conformal(Tool):
 
     def __init__(self, design):
         super().__init__(design)
-        self.build = BUILD_DIR / design / "conformal"
+        self.build = self.design_build_path / "conformal"
         self.__create_build_dir()
         self._init_outputs()
         self._read_hdl_files()

--- a/bfasst/ninja_tools/compare/conformal/conformal.py
+++ b/bfasst/ninja_tools/compare/conformal/conformal.py
@@ -2,7 +2,7 @@
 
 import chevron
 from bfasst.ninja_tools.tool import Tool
-from bfasst.paths import BUILD_DIR, NINJA_BUILD_PATH, NINJA_CONFORMAL_TOOLS_PATH, NINJA_UTILS_PATH
+from bfasst.paths import NINJA_BUILD_PATH, NINJA_CONFORMAL_TOOLS_PATH, NINJA_UTILS_PATH
 
 
 class Conformal(Tool):

--- a/bfasst/ninja_tools/compare/structural/structural.py
+++ b/bfasst/ninja_tools/compare/structural/structural.py
@@ -10,7 +10,7 @@ class Structural(Tool):
 
     def __init__(self, design):
         super().__init__(design)
-        self.build = BUILD_DIR / design / "struct_cmp"
+        self.build = self.design_build_path / "struct_cmp"
         self.__create_build_dir()
         self.log_name = None
 

--- a/bfasst/ninja_tools/compare/structural/structural.py
+++ b/bfasst/ninja_tools/compare/structural/structural.py
@@ -2,7 +2,7 @@
 
 import chevron
 from bfasst.ninja_tools.tool import Tool
-from bfasst.paths import BUILD_DIR, NINJA_BUILD_PATH, NINJA_STRUCTURAL_TOOLS_PATH, NINJA_UTILS_PATH
+from bfasst.paths import NINJA_BUILD_PATH, NINJA_STRUCTURAL_TOOLS_PATH, NINJA_UTILS_PATH
 
 
 class Structural(Tool):

--- a/bfasst/ninja_tools/compare/yosys/yosys.py
+++ b/bfasst/ninja_tools/compare/yosys/yosys.py
@@ -12,7 +12,7 @@ class Yosys(Tool):
 
     def __init__(self, design):
         super().__init__(design)
-        self.build = BUILD_DIR / design / "yosys"
+        self.build = self.design_build_path / "yosys"
         self.log = self.build / "log.txt"
         self.json = self.build / "yosys.json"
         self.tcl = self.build / "compare.ys"

--- a/bfasst/ninja_tools/compare/yosys/yosys.py
+++ b/bfasst/ninja_tools/compare/yosys/yosys.py
@@ -3,7 +3,7 @@
 import json
 import chevron
 from bfasst.ninja_tools.tool import Tool
-from bfasst.paths import BUILD_DIR, NINJA_BUILD_PATH, NINJA_UTILS_PATH, NINJA_YOSYS_TOOLS_PATH
+from bfasst.paths import NINJA_BUILD_PATH, NINJA_UTILS_PATH, NINJA_YOSYS_TOOLS_PATH
 from bfasst.utils.general import compare_json
 
 

--- a/bfasst/ninja_tools/rev_bit/xray.py
+++ b/bfasst/ninja_tools/rev_bit/xray.py
@@ -19,10 +19,10 @@ class Xray(Tool):
     def __init__(self, design):
         super().__init__(design)
 
-        self.build = BUILD_DIR / design / "xray"
+        self.build = self.design_build_path / "xray"
         self.__create_build_dirs()
 
-        self.top = YamlParser(self.design / "design.yaml").parse_top_module()
+        self.top = YamlParser(self.design_path / "design.yaml").parse_top_module()
 
         # get these moved to paths later
         self.fasm2bels_path = get_fasm2bels_path()

--- a/bfasst/ninja_tools/rev_bit/xray.py
+++ b/bfasst/ninja_tools/rev_bit/xray.py
@@ -2,13 +2,7 @@
 
 import chevron
 from bfasst import config
-from bfasst.paths import (
-    BUILD_DIR,
-    NINJA_BUILD_PATH,
-    REV_BIT_TOOLS_PATH,
-    XRAY_PATH,
-    get_fasm2bels_path,
-)
+from bfasst.paths import NINJA_BUILD_PATH, REV_BIT_TOOLS_PATH, XRAY_PATH, get_fasm2bels_path
 from bfasst.ninja_tools.tool import Tool
 from bfasst.yaml_parser import YamlParser
 

--- a/bfasst/ninja_tools/tool.py
+++ b/bfasst/ninja_tools/tool.py
@@ -2,15 +2,16 @@
 
 import abc
 
-from bfasst.paths import DESIGNS_PATH
+from bfasst.paths import BUILD_DIR, DESIGNS_PATH
 from bfasst.yaml_parser import YamlParser
 
 
 class Tool(abc.ABC):
     """Manage creating rule and build snippets"""
 
-    def __init__(self, design):
-        self.design = DESIGNS_PATH / design
+    def __init__(self, design_path):
+        self.design_path = design_path
+        self.design_build_path = BUILD_DIR / design_path.relative_to(DESIGNS_PATH)
         self.verilog = None
         self.system_verilog = None
         self.vhdl = None
@@ -40,8 +41,8 @@ class Tool(abc.ABC):
         self.verilog = []
         self.system_verilog = []
         self.vhdl = []
-        self.vhdl_libs = YamlParser(self.design / "design.yaml").parse_vhdl_libs()
-        for child in self.design.rglob("*"):
+        self.vhdl_libs = YamlParser(self.design_path / "design.yaml").parse_vhdl_libs()
+        for child in self.design_path.rglob("*"):
             if child.is_dir():
                 continue
 

--- a/bfasst/ninja_tools/transform/error_injector.py
+++ b/bfasst/ninja_tools/transform/error_injector.py
@@ -11,9 +11,9 @@ class ErrorInjector(Tool):
 
     def __init__(self, design):
         super().__init__(design)
-        self.build = BUILD_DIR / design / "error_injection"
+        self.build = self.design_build_path / "error_injection"
         self.__create_build_dir()
-        self.top = YamlParser(self.design / "design.yaml").parse_top_module()
+        self.top = YamlParser(self.design_path / "design.yaml").parse_top_module()
         self.injection_log = None
         self.corrupt_netlist = None
 

--- a/bfasst/ninja_tools/transform/error_injector.py
+++ b/bfasst/ninja_tools/transform/error_injector.py
@@ -1,8 +1,9 @@
 """Create the rule and build snippets for error injection into an xray netlist."""
 
 import chevron
+
 from bfasst.ninja_tools.tool import Tool
-from bfasst.paths import BUILD_DIR, NINJA_BUILD_PATH, NINJA_TRANSFORM_TOOLS_PATH, NINJA_UTILS_PATH
+from bfasst.paths import NINJA_BUILD_PATH, NINJA_TRANSFORM_TOOLS_PATH, NINJA_UTILS_PATH
 from bfasst.yaml_parser import YamlParser
 
 

--- a/bfasst/ninja_tools/transform/phys_netlist.py
+++ b/bfasst/ninja_tools/transform/phys_netlist.py
@@ -5,7 +5,6 @@ import json
 import chevron
 from bfasst.ninja_tools.tool import Tool
 from bfasst.paths import (
-    BUILD_DIR,
     NINJA_BUILD_PATH,
     NINJA_TRANSFORM_TOOLS_PATH,
     NINJA_UTILS_PATH,

--- a/bfasst/ninja_tools/transform/phys_netlist.py
+++ b/bfasst/ninja_tools/transform/phys_netlist.py
@@ -20,7 +20,7 @@ class PhysNetlist(Tool):
     def __init__(self, design):
         super().__init__(design)
 
-        self.build = BUILD_DIR / design / "vivado_phys_netlist"
+        self.build = self.design_build_path / "vivado_phys_netlist"
         self.phys_netlist_path = self.build / "viv_impl_physical.v"
         self.__create_build_dir()
 

--- a/bfasst/ninja_tools/vivado/vivado.py
+++ b/bfasst/ninja_tools/vivado/vivado.py
@@ -5,7 +5,6 @@ import chevron
 from bfasst import config
 from bfasst.ninja_tools.tool import Tool
 from bfasst.paths import (
-    BUILD_DIR,
     NINJA_IMPL_TOOLS_PATH,
     NINJA_BUILD_PATH,
     NINJA_VIVADO_TOOLS_PATH,
@@ -26,14 +25,15 @@ class Vivado(Tool):
 
         self.ooc = ooc
         if ooc:
-            self.build = BUILD_DIR / design / "ooc"
+            self.build = self.design_build_path / "ooc"
         else:
-            self.build = BUILD_DIR / design / "in_context"
+            self.build = self.design_build_path / "in_context"
+
         self.synth_output = self.build / "synth"
         self.impl_output = self.build / "impl"
         self.__create_build_dirs()
 
-        self.top = YamlParser(self.design / "design.yaml").parse_top_module()
+        self.top = YamlParser(self.design_path / "design.yaml").parse_top_module()
 
         # outputs must be initialized AFTER output paths are set
         self._init_outputs()
@@ -55,7 +55,7 @@ class Vivado(Tool):
             return
 
         for lib in self.vhdl_libs:
-            path = self.design / lib
+            path = self.design_path / lib
             for file in path.rglob("*"):
                 if file.is_dir():
                     continue

--- a/bfasst/utils/general.py
+++ b/bfasst/utils/general.py
@@ -174,8 +174,8 @@ def clean_error_injections_and_comparisons(designs):
     fail_list = []
 
     for design in designs:
-        cmp_dir = BUILD_DIR / design / "struct_cmp"
-        error_dir = BUILD_DIR / design / "error_injection"
+        cmp_dir = BUILD_DIR / design.relative_to(DESIGNS_PATH) / "struct_cmp"
+        error_dir = BUILD_DIR / design.relative_to(DESIGNS_PATH) / "error_injection"
         for file in cmp_dir.iterdir():
             with open(file, "r") as f:
                 # SUCCESS means the compare tool did not detect an actual error
@@ -226,3 +226,12 @@ def get_hdl_src_type(file, hdl_type=None):
 
     assert hdl_type is not None
     return hdl_type
+
+
+def ensure_tuple(x):
+    """If x is not a tuple, convert to tuple"""
+    if isinstance(x, tuple):
+        return x
+    if isinstance(x, list):
+        return tuple(x)
+    return (x,)

--- a/scripts/bfasster.py
+++ b/scripts/bfasster.py
@@ -1,11 +1,12 @@
 """Script to run a flow on one or more designs."""
-from argparse import ArgumentParser
+import argparse
 import pathlib
 import subprocess
+
 from bfasst.ninja_flows.ninja_flow_manager import NinjaFlowManager
 from bfasst.utils.general import clean_error_injections_and_comparisons
 from bfasst.yaml_parser import YamlParser
-from bfasst.utils import error
+from bfasst.utils import error, ensure_tuple
 from bfasst.paths import ROOT_PATH
 
 
@@ -18,59 +19,59 @@ class ApplicationRunner:
         self.deps = None
         self.flow_args = None
 
-    def run(self, args):
-        """Run a flow on one or more designs."""
+    def run_designs(self, flow, designs):
+        """Run one ore more designs with a given flow."""
+        self.designs = ensure_tuple(designs)
+        self.flow = flow
+        self.flow_args = {}
+        self.__run_ninja()
 
-        # save the flow and design paths
-        self.__parse_args(args)
+    def run_yaml(self, yaml_path):
+        """Run using a yaml configuration file"""
 
+        yaml_parser = YamlParser(args.yaml)
+        yaml_parser.parse_design_flow()
+
+        self.designs = yaml_parser.design_paths
+        self.flow = yaml_parser.flow
+        self.flow_args = yaml_parser.flow_args
+        self.__run_ninja()
+
+    def __run_ninja(self):
         # create a flow manager to handle the build.ninja file creation and update by flows
         flow_manager = NinjaFlowManager()
         flow_manager.create_flows(self.flow, self.designs, self.flow_args)
         flow_manager.run_flows()
 
         # run the build.ninja file
-        ninja_return_code = self.__run_ninja()
+        cmd = ["ninja"]
+        proc = subprocess.Popen(cmd, cwd=ROOT_PATH)
+        proc.communicate()
+        return_code = proc.wait()
 
         # for the error injector flow, print the list of failed comparisons
         if self.flow == "vivado_structural_error_injection":
             clean_error_injections_and_comparisons(self.designs)
 
-        if ninja_return_code != 0:
-            error("Ninja failed with return code", ninja_return_code)
-
-    def __parse_args(self, args):
-        if args.yaml:
-            yaml_parser = YamlParser(args.yaml)
-            yaml_parser.parse_design_flow()
-            self.designs = yaml_parser.design_paths
-            self.flow = yaml_parser.flow
-            self.flow_args = yaml_parser.flow_args
-        else:
-            self.flow = args.flow
-            self.designs = [args.design]
-
-    def __run_ninja(self):
-        cmd = ["ninja"]
-        proc = subprocess.Popen(cmd, cwd=ROOT_PATH)
-        proc.communicate()
-        return_code = proc.wait()
-        return return_code
-
-
-def check_args(args):
-    if args.yaml and (args.design or args.flow):
-        error("Cannot specify both a yaml file and a design/flow")
-    elif not args.yaml and not (args.design and args.flow):
-        error("Must specify either a yaml file or a design/flow")
+        if return_code != 0:
+            error("Ninja failed with return code", return_code)
 
 
 if __name__ == "__main__":
-    arg_parser = ArgumentParser()
-    arg_parser.add_argument("--yaml", type=pathlib.Path, help="Yaml file with flow specs")
-    arg_parser.add_argument("--design", type=str, help="Design directory for single design flows")
-    arg_parser.add_argument("--flow", type=str, help="Flow to run for single design flows")
-    runner_args = arg_parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--yaml", type=pathlib.Path, help="Yaml file with flow specs")
+    parser.add_argument(
+        "--design", type=pathlib.Path, help="Design directory for single design flows"
+    )
+    parser.add_argument("--flow", type=str, help="Flow to run for single design flows")
+    args = parser.parse_args()
 
-    check_args(runner_args)
-    ApplicationRunner().run(runner_args)
+    if args.yaml and (args.design or args.flow):
+        parser.error("Cannot specify both a yaml file and a design/flow")
+    elif not args.yaml and not (args.design and args.flow):
+        parser.error("Must specify either a yaml file or a design/flow")
+
+    if args.yaml:
+        ApplicationRunner().run_yaml(args.yaml)
+    else:
+        ApplicationRunner().run_designs(args.flow, args.design)

--- a/scripts/bfasster.py
+++ b/scripts/bfasster.py
@@ -29,7 +29,7 @@ class ApplicationRunner:
     def run_yaml(self, yaml_path):
         """Run using a yaml configuration file"""
 
-        yaml_parser = YamlParser(args.yaml)
+        yaml_parser = YamlParser(yaml_path)
         yaml_parser.parse_design_flow()
 
         self.designs = yaml_parser.design_paths


### PR DESCRIPTION
This updates the ninja system to do a few things:
* Expand all paths to absolute paths before passing them to the tools 
* Update the tools to expect this absolute path and create the build directories using relative_to (Fixed #311)
* Update the `Flow` class to track the design.  We are only using this in one place, but it might be useful in the future
* Update bfasster.py to not pass argument dictionaries between the functions and to better provide error messages on incorrect usages.
* Add pylint ignore to fix #306 