### PR TITLE
cli flow names

### DIFF
--- a/bfasst/flows/flow_descriptions.yaml
+++ b/bfasst/flows/flow_descriptions.yaml
@@ -3,43 +3,88 @@ flows:
   description: Run Xilinx Vivado from RTL to bitstream
   module: vivado
   class: Vivado
+  tools:
+  - VivadoSynth
+  - VivadoImpl
 
 - name: VivadoOoc
   description: Run Xilinx Vivado from RTL to implementation, with out-of-context synthesis
   module: vivado_ooc
   class: VivadoOoc
+  tools:
+  - VivadoSynth
+  - VivadoImpl
 
 - name: VivadoPhysNetlist
   description: Run Xilinx Vivado from RTL to bitstream, transforming the post-implementation netlist into a physical netlist
   module: vivado_phys_netlist
   class: VivadoPhysNetlist
+  tools:
+  - VivadoSynth
+  - VivadoImpl
+  - PhysNetlist
 
 - name: VivadoPhysNetlistCmp
   description: Run the VivadoPhysNetlist flow, then reverse the bitstream and structurally compare the two physical netlists
   module: vivado_phys_netlist_cmp
   class: VivadoPhysNetlistCmp
+  tools:
+  - VivadoSynth
+  - VivadoImpl
+  - PhysNetlist
+  - Xray
+  - NetlistCleanup
+  - Structural
+
 
 - name: VivadoStructuralErrorInjection
   description: Perform fault-injection testing of the structural comparison tool
   module: vivado_structural_error_injection
   class: VivadoStructuralErrorInjection
+  tools:
+  - VivadoSynth
+  - VivadoImpl
+  - PhysNetlist
+  - Xray
+  - ErrorInjector
+  - Structural
+
 
 - name: VivadoYosysImpl
   description: Run Yosys to compare Vivado post-implementation netlist to Xray (bit-reversed) netlist
   module: vivado_yosys_impl
   class: VivadoYosysImpl
+  tools:
+  - VivadoSynth
+  - VivadoImpl
+  - Xray
+  - Yosys
 
 - name: VivadoConformal
   description: Run Cadence Conformal to compare Vivado post-implementation netlist to Xray (bit-reversed) netlist
   module: vivado_conformal
   class: VivadoConformal
+  tools:
+  - VivadoSynth
+  - VivadoImpl
+  - Xray
+  - Conformal
 
 - name: VivadoBitAnalysis
   description: Reverse a Vivado generated bitstream into a logical netlist
   module: vivado_bit_analysis
   class: VivadoBitAnalysis
+  tools:
+  - VivadoSynth
+  - VivadoImpl
+  - Xray
+  - NetlistCleanup
+  - NetlistPhysToLogical
 
 - name: RandSoc
   description: Create random block design(s) in Vivado
   module: rand_soc
   class: RandSoc
+  tools:
+  - VivadoSynth
+  - VivadoSynthFromTcl

--- a/bfasst/flows/flow_descriptions.yaml
+++ b/bfasst/flows/flow_descriptions.yaml
@@ -1,0 +1,45 @@
+flows:
+- name: Vivado
+  description: Run Xilinx Vivado from RTL to bitstream
+  module: vivado
+  class: Vivado
+
+- name: VivadoOoc
+  description: Run Xilinx Vivado from RTL to implementation, with out-of-context synthesis
+  module: vivado_ooc
+  class: VivadoOoc
+
+- name: VivadoPhysNetlist
+  description: Run Xilinx Vivado from RTL to bitstream, transforming the post-implementation netlist into a physical netlist
+  module: vivado_phys_netlist
+  class: VivadoPhysNetlist
+
+- name: VivadoPhysNetlistCmp
+  description: Run the VivadoPhysNetlist flow, then reverse the bitstream and structurally compare the two physical netlists
+  module: vivado_phys_netlist_cmp
+  class: VivadoPhysNetlistCmp
+
+- name: VivadoStructuralErrorInjection
+  description: Perform fault-injection testing of the structural comparison tool
+  module: vivado_structural_error_injection
+  class: VivadoStructuralErrorInjection
+
+- name: VivadoYosysImpl
+  description: Run Yosys to compare Vivado post-implementation netlist to Xray (bit-reversed) netlist
+  module: vivado_yosys_impl
+  class: VivadoYosysImpl
+
+- name: VivadoConformal
+  description: Run Cadence Conformal to compare Vivado post-implementation netlist to Xray (bit-reversed) netlist
+  module: vivado_conformal
+  class: VivadoConformal
+
+- name: VivadoBitAnalysis
+  description: Reverse a Vivado generated bitstream into a logical netlist
+  module: vivado_bit_analysis
+  class: VivadoBitAnalysis
+
+- name: RandSoc
+  description: Create random block design(s) in Vivado
+  module: rand_soc
+  class: RandSoc

--- a/bfasst/flows/flow_utils.py
+++ b/bfasst/flows/flow_utils.py
@@ -1,29 +1,5 @@
 """Utility methods for getting flows"""
-from importlib import import_module
-from pathlib import Path
-
 from bfasst.paths import NINJA_BUILD_PATH
-
-
-def get_flows():
-    """Get all flows in the flows directory"""
-    special_names = [
-        "__init__",
-        "flow_utils",
-        "flow",
-        "ninja_flow_manager",
-    ]
-    flows = [
-        flow.stem for flow in Path(__file__).parent.glob("*.py") if flow.stem not in special_names
-    ]
-    return flows
-
-
-def get_flow(flow_name):
-    """Get a flow by name"""
-    flow_module = import_module(f"bfasst.flows.{flow_name}")
-    flow_class = "".join(word.capitalize() for word in flow_name.split("_"))
-    return getattr(flow_module, flow_class)
 
 
 def create_build_file():

--- a/bfasst/flows/ninja_flow_manager.py
+++ b/bfasst/flows/ninja_flow_manager.py
@@ -6,9 +6,10 @@ import pathlib
 import chevron
 
 from bfasst.flows.flow import FlowNoDesign
-from bfasst.flows.flow_utils import create_build_file, get_flow
+from bfasst.flows.flow_utils import create_build_file
 from bfasst.paths import DESIGNS_PATH, NINJA_BUILD_PATH, FLOWS_PATH, ROOT_PATH
 from bfasst.utils import error
+from bfasst.yaml_parser import FlowDescriptionParser
 
 
 class NinjaFlowManager:
@@ -37,7 +38,7 @@ class NinjaFlowManager:
         self.flows = []
         self.designs = []
 
-        flow_class = get_flow(flow_name)
+        flow_class: type = FlowDescriptionParser().get_flow_class(flow_name)
 
         if issubclass(flow_class, FlowNoDesign):
             assert not designs, (
@@ -63,7 +64,7 @@ class NinjaFlowManager:
 
                 self.designs.append(design_path)
 
-                flow = get_flow(flow_name)(design_path, **self.flow_arguments)
+                flow = flow_class(design_path, **self.flow_arguments)
                 self.flows.append(flow)
 
         for flow in self.flows:

--- a/bfasst/flows/rand_soc.py
+++ b/bfasst/flows/rand_soc.py
@@ -2,7 +2,7 @@
 import pathlib
 
 from bfasst.flows.flow import FlowNoDesign
-from bfasst.tools.design_create.rand_soc import RandSoCTool
+from bfasst.tools.design_create.rand_soc import RandSoC
 from bfasst.tools.synth.vivado_synth_tcl import VivadoSynthFromTcl
 
 
@@ -12,7 +12,7 @@ class RandSoc(FlowNoDesign):
     def __init__(self, num_designs=1):
         super().__init__()
 
-        self.rand_soc_tool = RandSoCTool(self, num_designs=num_designs)
+        self.rand_soc_tool = RandSoC(self, num_designs=num_designs)
 
         for design in self.rand_soc_tool.outputs["design_tcl"]:
             VivadoSynthFromTcl(self, design)

--- a/bfasst/flows/vivado_bit_analysis.py
+++ b/bfasst/flows/vivado_bit_analysis.py
@@ -4,9 +4,9 @@ import pathlib
 
 from bfasst.flows.flow import Flow
 from bfasst.tools.impl.vivado_impl import VivadoImpl
-from bfasst.tools.rev_bit.xray import Xray as XrevTool
-from bfasst.tools.transform.netlist_cleanup import NetlistCleanupTool
-from bfasst.tools.transform.netlist_phys_to_logical import NetlistPhysToLogicalTool
+from bfasst.tools.rev_bit.xray import Xray
+from bfasst.tools.transform.netlist_cleanup import NetlistCleanup
+from bfasst.tools.transform.netlist_phys_to_logical import NetlistPhysToLogical
 from bfasst.tools.synth.vivado_synth import VivadoSynth
 
 
@@ -17,9 +17,9 @@ class VivadoBitAnalysis(Flow):
         super().__init__(design)
         self.vivado_synth_tool = VivadoSynth(self, design, synth_options=synth_options)
         self.vivado_impl_tool = VivadoImpl(self, design)
-        self.xrev_tool = XrevTool(self, design)
-        self.netlist_cleanup_tool = NetlistCleanupTool(self, design)
-        self.netlist_phys_to_logical = NetlistPhysToLogicalTool(self, design)
+        self.xrev_tool = Xray(self, design)
+        self.netlist_cleanup_tool = NetlistCleanup(self, design)
+        self.netlist_phys_to_logical = NetlistPhysToLogical(self, design)
 
     def create_build_snippets(self):
         self.vivado_synth_tool.create_build_snippets()

--- a/bfasst/flows/vivado_phys_netlist_cmp.py
+++ b/bfasst/flows/vivado_phys_netlist_cmp.py
@@ -5,7 +5,7 @@ from bfasst.flows.vivado_phys_netlist import VivadoPhysNetlist
 from bfasst.tools.impl.vivado_impl import VivadoImpl
 from bfasst.tools.compare.structural.structural import Structural
 from bfasst.tools.rev_bit.xray import Xray
-from bfasst.tools.transform.netlist_cleanup import NetlistCleanupTool
+from bfasst.tools.transform.netlist_cleanup import NetlistCleanup
 from bfasst.tools.transform.phys_netlist import PhysNetlist
 from bfasst.paths import FLOWS_PATH
 from bfasst.tools.synth.vivado_synth import VivadoSynth
@@ -23,7 +23,7 @@ class VivadoPhysNetlistCmp(Flow):
         self.vivado_impl_tool = VivadoImpl(self, design)
         self.phys_netlist_tool = PhysNetlist(self, design)
         self.xray_tool = Xray(self, design)
-        self.cleanup_tool = NetlistCleanupTool(self, design)
+        self.cleanup_tool = NetlistCleanup(self, design)
         self.compare_tool = Structural(self, design)
 
     def create_build_snippets(self):

--- a/bfasst/tools/design_create/rand_soc.py
+++ b/bfasst/tools/design_create/rand_soc.py
@@ -7,7 +7,7 @@ from bfasst.tools.tool import ToolBase
 from bfasst.paths import BUILD_PATH, GMT_TOOLS_PATH, NINJA_BUILD_PATH
 
 
-class RandSoCTool(ToolBase):
+class RandSoC(ToolBase):
     """Tool to create a random SoC"""
 
     def __init__(self, flow, num_designs):

--- a/bfasst/tools/transform/netlist_cleanup.py
+++ b/bfasst/tools/transform/netlist_cleanup.py
@@ -6,7 +6,7 @@ from bfasst.tools.tool import Tool
 from bfasst.paths import NINJA_UTILS_PATH
 
 
-class NetlistCleanupTool(Tool):
+class NetlistCleanup(Tool):
     """Create rule and build snippets for phys netlist creation."""
 
     def __init__(self, flow, design):

--- a/bfasst/tools/transform/netlist_phys_to_logical.py
+++ b/bfasst/tools/transform/netlist_phys_to_logical.py
@@ -5,7 +5,7 @@ from bfasst.tools.tool import Tool
 from bfasst.paths import BFASST_UTILS_PATH, GMT_TOOLS_PATH
 
 
-class NetlistPhysToLogicalTool(Tool):
+class NetlistPhysToLogical(Tool):
     """Create rule and build snippets for phys netlist creation."""
 
     def __init__(self, flow, design):

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -5,9 +5,8 @@ import pathlib
 import subprocess
 import sys
 
-from bfasst.flows.flow_utils import get_flows
 from bfasst.flows.ninja_flow_manager import NinjaFlowManager
-from bfasst.yaml_parser import RunParser
+from bfasst.yaml_parser import FlowDescriptionParser, RunParser
 from bfasst.utils import error, ensure_tuple
 from bfasst.paths import ROOT_PATH
 
@@ -58,6 +57,14 @@ class ApplicationRunner:
             error("Ninja failed with return code", return_code)
 
 
+def get_flow_choices() -> list[str]:
+    """Get a list of formatted flow choices"""
+    return [
+        f"    {flow_name:<35}{flow_description}"
+        for flow_name, flow_description in FlowDescriptionParser().get_flow_names_and_descriptions()
+    ]
+
+
 def parse_args(args):
     """Parse main arguments"""
     parser = argparse.ArgumentParser()
@@ -74,7 +81,9 @@ def parse_args(args):
     )
     args = parser.parse_args(args)
 
-    if args.flow_name_or_yaml_path in get_flows():
+    flows_list = FlowDescriptionParser().get_flow_names()
+
+    if args.flow_name_or_yaml_path in flows_list:
         args.flow = args.flow_name_or_yaml_path
     elif pathlib.Path(args.flow_name_or_yaml_path).is_file():
         args.yaml = pathlib.Path(args.flow_name_or_yaml_path)
@@ -83,10 +92,12 @@ def parse_args(args):
             "Specify them in the yaml file instead."
         )
     else:
+        flow_choices: str = "\n".join(get_flow_choices())
         parser.error(
             (
                 f"First argument ({args.flow_name_or_yaml_path}) must specify either a yaml file "
-                f"or a flow name. Valid flow names: {get_flows()}"
+                f"or a flow name. Valid flow names:\n"
+                f"{flow_choices}"
             )
         )
 

--- a/test/flows/test_vivado_bit_analysis_flow.py
+++ b/test/flows/test_vivado_bit_analysis_flow.py
@@ -8,8 +8,8 @@ import unittest
 from bfasst.flows.flow_utils import create_build_file
 from bfasst.flows.vivado_bit_analysis import VivadoBitAnalysis
 from bfasst.tools.rev_bit.xray import Xray
-from bfasst.tools.transform.netlist_cleanup import NetlistCleanupTool
-from bfasst.tools.transform.netlist_phys_to_logical import NetlistPhysToLogicalTool
+from bfasst.tools.transform.netlist_cleanup import NetlistCleanup
+from bfasst.tools.transform.netlist_phys_to_logical import NetlistPhysToLogical
 from bfasst.tools.synth.vivado_synth import VivadoSynth
 from bfasst.tools.impl.vivado_impl import VivadoImpl
 from bfasst.paths import (
@@ -59,8 +59,8 @@ class TestVivadoAndReversedFlow(unittest.TestCase):
         Xray(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
         VivadoSynth(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
         VivadoImpl(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
-        NetlistCleanupTool(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
-        NetlistPhysToLogicalTool(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
+        NetlistCleanup(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
+        NetlistPhysToLogical(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
         expected.append(FLOWS_PATH / "vivado_bit_analysis.py")
 
         observed = sorted([str(s) for s in observed])
@@ -68,9 +68,7 @@ class TestVivadoAndReversedFlow(unittest.TestCase):
         self.assertEqual(observed, expected)
 
     def test_get_top_level_flow_path(self):
-        self.assertEqual(
-            self.flow.get_top_level_flow_path(), FLOWS_PATH / "vivado_bit_analysis.py"
-        )
+        self.assertEqual(self.flow.get_top_level_flow_path(), FLOWS_PATH / "vivado_bit_analysis.py")
 
 
 if __name__ == "__main__":

--- a/test/flows/test_vivado_phys_netlist_cmp_flow.py
+++ b/test/flows/test_vivado_phys_netlist_cmp_flow.py
@@ -9,7 +9,7 @@ from bfasst.flows.flow_utils import create_build_file
 from bfasst.flows.vivado_phys_netlist_cmp import VivadoPhysNetlistCmp
 from bfasst.tools.compare.structural.structural import Structural
 from bfasst.tools.rev_bit.xray import Xray
-from bfasst.tools.transform.netlist_cleanup import NetlistCleanupTool
+from bfasst.tools.transform.netlist_cleanup import NetlistCleanup
 from bfasst.tools.transform.phys_netlist import PhysNetlist
 from bfasst.tools.synth.vivado_synth import VivadoSynth
 from bfasst.tools.impl.vivado_impl import VivadoImpl
@@ -64,7 +64,7 @@ class TestVivadoPhysNetlistCmp(unittest.TestCase):
         VivadoImpl(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
         PhysNetlist(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
         Xray(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
-        NetlistCleanupTool(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
+        NetlistCleanup(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
         Structural(None, DESIGNS_PATH / "byu/alu").add_ninja_deps(expected)
         expected.append(FLOWS_PATH / "vivado_phys_netlist_cmp.py")
 


### PR DESCRIPTION
Fixes #382, Fixes #362
﻿- fixed cli flow conventions and help message
- updated to handle differences in ci yaml files vs cli arguments for flow specification
- Renamed tools to remove redundant 'Tool' postfix from the names and match previous convention
- updated flow descriptions to include a list of tools that each flow uses
- removed redundant code and added method to get flow tools from flow_descriptions.yaml on a per flow basis
