### PR TITLE
add NetlistCleanupTool to StructuralErrorInjection

### DIFF
--- a/bfasst/utils/netlist_cleanup.py
+++ b/bfasst/utils/netlist_cleanup.py
@@ -67,7 +67,8 @@ class NetlistCleaner:
                         instance_wrapper.get_pin(pin_name).pin.wire
                     ).is_connected
                     for pin_name in pin_names
-                    if (pin_name, 0) in instance_wrapper.pins_by_name_and_index and instance_wrapper.get_pin(pin_name).pin.wire is not None
+                    if (pin_name, 0) in instance_wrapper.pins_by_name_and_index
+                    and instance_wrapper.get_pin(pin_name).pin.wire is not None
                 )
                 if not any(connected_pins):
                     top.reference.remove_child(instance_wrapper.instance)

--- a/bfasst/utils/netlist_cleanup.py
+++ b/bfasst/utils/netlist_cleanup.py
@@ -63,10 +63,11 @@ class NetlistCleaner:
                 logging.info("Processing %s %s", instance_type, instance_wrapper.name)
 
                 connected_pins = (
-                    netlist_wrapper.wire_to_net[
+                    netlist_wrapper.wire_to_net.get(
                         instance_wrapper.get_pin(pin_name).pin.wire
-                    ].is_connected
+                    ).is_connected
                     for pin_name in pin_names
+                    if (pin_name, 0) in instance_wrapper.pins_by_name_and_index and instance_wrapper.get_pin(pin_name).pin.wire is not None
                 )
                 if not any(connected_pins):
                     top.reference.remove_child(instance_wrapper.instance)

--- a/test/flows/test_vivado_structural_error_injection_flow.py
+++ b/test/flows/test_vivado_structural_error_injection_flow.py
@@ -13,6 +13,7 @@ from bfasst.tools.transform.error_injector import ErrorInjector
 from bfasst.tools.transform.phys_netlist import PhysNetlist
 from bfasst.tools.synth.vivado_synth import VivadoSynth
 from bfasst.tools.impl.vivado_impl import VivadoImpl
+from bfasst.tools.transform.netlist_cleanup import NetlistCleanup
 from bfasst.paths import (
     DESIGNS_PATH,
     NINJA_BUILD_PATH,
@@ -50,8 +51,8 @@ class TestVivadoStructuralErrorInjection(unittest.TestCase):
         with open(NINJA_BUILD_PATH, "r") as f:
             build_statement_count = f.read().count("\nbuild ")
 
-        # there should be 410 build statements for a single design using this flow
-        self.assertEqual(build_statement_count, 410)
+        # there should be 411 build statements for a single design using this flow
+        self.assertEqual(build_statement_count, 411)
 
     def test_add_ninja_deps(self):
         """Test that the flow adds the correct dependencies to the ninja file"""
@@ -66,6 +67,7 @@ class TestVivadoStructuralErrorInjection(unittest.TestCase):
         VivadoImpl(None, desin_path).add_ninja_deps(expected)
         ErrorInjector(None, desin_path).add_ninja_deps(expected)
         PhysNetlist(None, desin_path).add_ninja_deps(expected)
+        NetlistCleanup(None, desin_path).add_ninja_deps(expected)
         Xray(None, desin_path).add_ninja_deps(expected)
         Structural(None, desin_path).add_ninja_deps(expected)
         expected.append(FLOWS_PATH / "vivado_structural_error_injection.py")

--- a/test/flows/test_vivado_structural_error_injection_flow.py
+++ b/test/flows/test_vivado_structural_error_injection_flow.py
@@ -62,14 +62,14 @@ class TestVivadoStructuralErrorInjection(unittest.TestCase):
             "foo",
             "bar",
         ]
-        desin_path = DESIGNS_PATH / "byu/alu"
-        VivadoSynth(None, desin_path).add_ninja_deps(expected)
-        VivadoImpl(None, desin_path).add_ninja_deps(expected)
-        ErrorInjector(None, desin_path).add_ninja_deps(expected)
-        PhysNetlist(None, desin_path).add_ninja_deps(expected)
-        NetlistCleanup(None, desin_path).add_ninja_deps(expected)
-        Xray(None, desin_path).add_ninja_deps(expected)
-        Structural(None, desin_path).add_ninja_deps(expected)
+        design_path = DESIGNS_PATH / "byu/alu"
+        VivadoSynth(None, design_path).add_ninja_deps(expected)
+        VivadoImpl(None, design_path).add_ninja_deps(expected)
+        ErrorInjector(None, design_path).add_ninja_deps(expected)
+        PhysNetlist(None, design_path).add_ninja_deps(expected)
+        NetlistCleanup(None, design_path).add_ninja_deps(expected)
+        Xray(None, design_path).add_ninja_deps(expected)
+        Structural(None, design_path).add_ninja_deps(expected)
         expected.append(FLOWS_PATH / "vivado_structural_error_injection.py")
 
         observed = sorted([str(s) for s in observed])

--- a/test/scripts/test_ninja_flow_manager.py
+++ b/test/scripts/test_ninja_flow_manager.py
@@ -106,7 +106,7 @@ class TestNinjaFlowManager(unittest.TestCase):
         # There should be 200 injections and 200 comparisons for two flows
         # plus all the build statements for the phys_reversed_flow
         # ((200 * 2) * 2) + 21 = 821 build statements
-        self.__check_flow_run("vivado_structural_error_injection", 411)
+        self.__check_flow_run("vivado_structural_error_injection", 412)
 
     def test_run_vivado_conformal_flow(self):
         self.__check_flow_run("vivado_conformal", 9)


### PR DESCRIPTION
- Added NetlistCleanupTool to StructuralErrorInjection flow
- Update tests
- Fix typos
- Resolved a KeyError in netlist_cleanup.py that occurred due to attempts to access non-existent pins in the pins_by_name_and_index dictionary
Fixes #394
