### PR TITLE
Took synth_options out of tests/weekly_tests/vivado_ooc.yaml

### DIFF
--- a/tests/weekly_tests/vivado_ooc.yaml
+++ b/tests/weekly_tests/vivado_ooc.yaml
@@ -1,6 +1,5 @@
 designs:
   - ooc/
 
-flow: vivado_ooc
+flow: VivadoOoc
 
-synth: "-flatten_hierarchy full"


### PR DESCRIPTION
The VivadoOoc flow doesn't expect any synth options. It errors if you try to give any. I'm not sure if that means it doesn't need any synth options, or if that needs to be added to the flow. @jgoeders @KeenanRileyFaulkner I'm not 100% clear on the effects "flatten_hierarchy full" has so some clarification would be nice.