### PR TITLE
Install tools needed for weeklytests

### DIFF
--- a/.github/workflows/weeklytests.yml
+++ b/.github/workflows/weeklytests.yml
@@ -42,11 +42,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         token: ${{ secrets.GMT_TOOLS_PAT }}
-      run: 
-        eval `ssh-agent -s`
-        ssh-add - <<< '${{ secrets.GMT_TOOLS_DEPLOY_SSH_KEY }}'
-        make env
-        . .venv/bin/activate && python bfasst/external_tools.py install rapidwright fasm2bels
+    - run: 
+      eval `ssh-agent -s`
+      ssh-add - <<< '${{ secrets.GMT_TOOLS_DEPLOY_SSH_KEY }}'
+      make env
+      . .venv/bin/activate && python bfasst/external_tools.py install rapidwright fasm2bels
     - uses: ./.github/actions/setup_env
     - name: tests
       timeout-minutes: 40

--- a/.github/workflows/weeklytests.yml
+++ b/.github/workflows/weeklytests.yml
@@ -42,11 +42,12 @@ jobs:
     - uses: actions/checkout@v3
       with:
         token: ${{ secrets.GMT_TOOLS_PAT }}
-    - run: |
+    - name: Install external tools
+      run: |
         eval `ssh-agent -s`
         ssh-add - <<< '${{ secrets.GMT_TOOLS_DEPLOY_SSH_KEY }}'
         make env
-        . .venv/bin/activate && python bfasst/external_tools.py install rapidwright fasm2bels
+        . .venv/bin/activate && python bfasst/external_tools.py install_test_yaml ${{ matrix.experiment }}
     - name: tests
       timeout-minutes: 40
       run: |

--- a/.github/workflows/weeklytests.yml
+++ b/.github/workflows/weeklytests.yml
@@ -43,10 +43,10 @@ jobs:
       with:
         token: ${{ secrets.GMT_TOOLS_PAT }}
     - run: |
-      eval `ssh-agent -s`
-      ssh-add - <<< '${{ secrets.GMT_TOOLS_DEPLOY_SSH_KEY }}'
-      make env
-      . .venv/bin/activate && python bfasst/external_tools.py install rapidwright fasm2bels
+        eval `ssh-agent -s`
+        ssh-add - <<< '${{ secrets.GMT_TOOLS_DEPLOY_SSH_KEY }}'
+        make env
+        . .venv/bin/activate && python bfasst/external_tools.py install rapidwright fasm2bels
     - uses: ./.github/actions/setup_env
     - name: tests
       timeout-minutes: 40

--- a/.github/workflows/weeklytests.yml
+++ b/.github/workflows/weeklytests.yml
@@ -47,7 +47,6 @@ jobs:
         ssh-add - <<< '${{ secrets.GMT_TOOLS_DEPLOY_SSH_KEY }}'
         make env
         . .venv/bin/activate && python bfasst/external_tools.py install rapidwright fasm2bels
-    - uses: ./.github/actions/setup_env
     - name: tests
       timeout-minutes: 40
       run: |

--- a/.github/workflows/weeklytests.yml
+++ b/.github/workflows/weeklytests.yml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         token: ${{ secrets.GMT_TOOLS_PAT }}
-    - run: 
+    - run: |
       eval `ssh-agent -s`
       ssh-add - <<< '${{ secrets.GMT_TOOLS_DEPLOY_SSH_KEY }}'
       make env

--- a/.github/workflows/weeklytests.yml
+++ b/.github/workflows/weeklytests.yml
@@ -42,7 +42,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         token: ${{ secrets.GMT_TOOLS_PAT }}
-        submodules: 'recursive'
+      run: 
+        eval `ssh-agent -s`
+        ssh-add - <<< '${{ secrets.GMT_TOOLS_DEPLOY_SSH_KEY }}'
+        make env
+        . .venv/bin/activate && python bfasst/external_tools.py install rapidwright fasm2bels
     - uses: ./.github/actions/setup_env
     - name: tests
       timeout-minutes: 40


### PR DESCRIPTION
- Installs tools correctly

After this change, vivado_full_ooc.yaml passed, error_injection.yaml timed out (make it faster, shorten the amount of runs, or increase the timeout time?), and vivado.yaml, vivado_ooc.yaml and phys_netlist_paper.yaml all failed on some designs