### PR TITLE
Const nets fix

### DIFF
--- a/bfasst/utils/rw_helpers.py
+++ b/bfasst/utils/rw_helpers.py
@@ -180,6 +180,8 @@ def transfer_global_pins(old_cells, new_cell, global_pins):
 
 def combine_const_nets(port, old_inst, new_inst):
     """
+    Moves the connections from multiple const nets to a single const net
+   
     Parameters:
     port (str)
     old_inst (EDIFCellInst)

--- a/bfasst/utils/rw_helpers.py
+++ b/bfasst/utils/rw_helpers.py
@@ -181,7 +181,7 @@ def transfer_global_pins(old_cells, new_cell, global_pins):
 def combine_const_nets(port, old_inst, new_inst):
     """
     Moves the connections from multiple const nets to a single const net
-   
+
     Parameters:
     port (str)
     old_inst (EDIFCellInst)

--- a/bfasst/utils/rw_helpers.py
+++ b/bfasst/utils/rw_helpers.py
@@ -185,8 +185,8 @@ def combine_const_nets(port, old_inst, new_inst):
     old_inst (EDIFCellInst)
     new_inst (EDIFCellInst)
     """
-    old_net = old_inst.getPortInst(port).getNet()    
-    main_net = new_inst.getPortInst(port).getNet()   
+    old_net = old_inst.getPortInst(port).getNet()
+    main_net = new_inst.getPortInst(port).getNet()
     port_insts = list(old_net.getPortInsts())
     ground_instances = []
     for port_inst in port_insts:
@@ -196,7 +196,7 @@ def combine_const_nets(port, old_inst, new_inst):
         else:
             ground_instances.append(port_inst)
     for ground_instance in ground_instances:
-        old_net.removePortInst(port_inst)
+        old_net.removePortInst(ground_instance)
 
 
 def remove_and_disconnect_cell(cell, log=logging.info):

--- a/bfasst/utils/rw_helpers.py
+++ b/bfasst/utils/rw_helpers.py
@@ -178,6 +178,27 @@ def transfer_global_pins(old_cells, new_cell, global_pins):
             net.removePortInst(old_port)
 
 
+def combine_const_nets(port, old_inst, new_inst):
+    """
+    Parameters:
+    port (str)
+    old_inst (EDIFCellInst)
+    new_inst (EDIFCellInst)
+    """
+    old_net = old_inst.getPortInst(port).getNet()    
+    main_net = new_inst.getPortInst(port).getNet()   
+    port_insts = list(old_net.getPortInsts())
+    ground_instances = []
+    for port_inst in port_insts:
+        if not port_inst.isPrimitiveStaticSource():
+            old_net.removePortInst(port_inst)
+            main_net.addPortInst(port_inst)
+        else:
+            ground_instances.append(port_inst)
+    for ground_instance in ground_instances:
+        old_net.removePortInst(port_inst)
+
+
 def remove_and_disconnect_cell(cell, log=logging.info):
     if isinstance(cell, Cell):
         cell = cell.getEDIFHierCellInst()

--- a/bfasst/utils/rw_phys_netlist.py
+++ b/bfasst/utils/rw_phys_netlist.py
@@ -126,8 +126,6 @@ class RwPhysNetlist:
                 )
                 for inst in cell_insts[1:]:
                     rw.combine_const_nets(port, inst, cell_insts[0])
-                    # self.rw_design.removeNet(inst.getPortInst(port).getNet().getName())
-                # remove old ground cells
 
             if cell_insts:
                 const_net = cell_insts[0].getPortInst(port).getNet()

--- a/bfasst/utils/rw_phys_netlist.py
+++ b/bfasst/utils/rw_phys_netlist.py
@@ -125,8 +125,9 @@ class RwPhysNetlist:
                     net_name,
                 )
                 for inst in cell_insts[1:]:
-                    rw.combine_const_nets(port, inst, cell_insts[0])
-                    self.rw_design.removeNet(inst.getPortInst(port).getNet().getName())
+                    rw.combine_const_nets(port, inst, cell_insts[0])               
+                    # self.rw_design.removeNet(inst.getPortInst(port).getNet().getName())
+                # remove old ground cells
 
             if cell_insts:
                 const_net = cell_insts[0].getPortInst(port).getNet()

--- a/bfasst/utils/rw_phys_netlist.py
+++ b/bfasst/utils/rw_phys_netlist.py
@@ -124,8 +124,8 @@ class RwPhysNetlist:
                     unisim,
                     net_name,
                 )
-                for inst in cell_insts[1:]:
-                    rw.combine_const_nets(port, inst, cell_insts[0])               
+                for inst in cell_insts[1:]:                 
+                    rw.combine_const_nets(port, inst, cell_insts[0])
                     # self.rw_design.removeNet(inst.getPortInst(port).getNet().getName())
                 # remove old ground cells
 

--- a/bfasst/utils/rw_phys_netlist.py
+++ b/bfasst/utils/rw_phys_netlist.py
@@ -124,7 +124,7 @@ class RwPhysNetlist:
                     unisim,
                     net_name,
                 )
-                for inst in cell_insts[1:]:                 
+                for inst in cell_insts[1:]:
                     rw.combine_const_nets(port, inst, cell_insts[0])
                     # self.rw_design.removeNet(inst.getPortInst(port).getNet().getName())
                 # remove old ground cells

--- a/bfasst/utils/rw_phys_netlist.py
+++ b/bfasst/utils/rw_phys_netlist.py
@@ -124,6 +124,9 @@ class RwPhysNetlist:
                     unisim,
                     net_name,
                 )
+                for inst in cell_insts[1:]:
+                    rw.combine_const_nets(port, inst, cell_insts[0])
+                    self.rw_design.removeNet(inst.getPortInst(port).getNet().getName())
 
             if cell_insts:
                 const_net = cell_insts[0].getPortInst(port).getNet()


### PR DESCRIPTION
If multiple const nets are found, the first one is used, and the rest have their connections moved over to the first net and then they're removed. Fixes a specific design failing.

@reillymck As of now I haven't added in the code that removes the extra GND nets and cells, but this works. Will those extra nets and cells even show up anywhere if they're not connected to anything?