### PR TITLE
pass weekly, small refactoring changes, implicit dependencies

### DIFF
--- a/.github/workflows/weeklytests.yml
+++ b/.github/workflows/weeklytests.yml
@@ -43,7 +43,7 @@ jobs:
         make env
         . .venv/bin/activate && python bfasst/external_tools.py install_test_yaml ${{ matrix.experiment }}
     - name: tests
-      timeout-minutes: 40
+      timeout-minutes: 60
       run: |
         source .venv/bin/activate
         python scripts/run.py ${{ matrix.experiment }}

--- a/bfasst/external_tools.py
+++ b/bfasst/external_tools.py
@@ -18,7 +18,7 @@ from bfasst.paths import (
     THIRD_PARTY_PATH,
     WAFOVE_PATH,
     YOSYS_PATH,
-    get_fasm2bels_path,
+    FASM2BELS_PATH,
 )
 from bfasst.utils.conformal import ConformalCompare
 from bfasst.utils.general import error
@@ -46,8 +46,7 @@ def check_icestorm():
 
 
 def check_fasm2bels():
-    fasm2bels_path = get_fasm2bels_path()
-    return (fasm2bels_path / "env").is_dir() and (fasm2bels_path / f"{PART}_db").is_file()
+    return (FASM2BELS_PATH / "env").is_dir() and (FASM2BELS_PATH / f"{PART}_db").is_file()
 
 
 def check_conformal():

--- a/bfasst/paths.py
+++ b/bfasst/paths.py
@@ -58,4 +58,9 @@ def get_fasm2bels_path():
     return THIRD_PARTY_PATH / "fasm2bels"
 
 
-XRAY_PATH = get_fasm2bels_path() / "third_party" / "prjxray"
+FASM2BELS_PATH = get_fasm2bels_path()
+FASM2BELS_PYTHON_PATH = (
+    FASM2BELS_PATH / "env" / "conda" / "envs" / "f4pga_xc_fasm2bels" / "bin" / "python3"
+)
+XRAY_PATH = FASM2BELS_PATH / "third_party" / "prjxray"
+XRAY_DB_PATH = FASM2BELS_PATH / "third_party" / "prjxray-db"

--- a/bfasst/tools/compare/conformal/conformal.py
+++ b/bfasst/tools/compare/conformal/conformal.py
@@ -19,7 +19,7 @@ class Conformal(Tool):
         self._init_outputs()
         # self._read_hdl_files()
         self.rule_snippet_path = CONFORMAL_TOOLS_PATH / "conformal_rules.ninja.mustache"
-        self.render_dict = {"utils": str(BFASST_UTILS_PATH)}
+        self.rules_render_dict = {"utils": str(BFASST_UTILS_PATH)}
 
     def create_build_snippets(self):
         """Create the build snippets for conformal comparison."""

--- a/bfasst/tools/compare/structural/structural_build.ninja.mustache
+++ b/bfasst/tools/compare/structural/structural_build.ninja.mustache
@@ -1,3 +1,3 @@
-build {{ log_path }}: compare {{ netlist_a }} {{ netlist_b }} | {{ compare_script_path }}
+build {{ log_path }}: compare {{ netlist_a }} {{ netlist_b }} | {{ compare_script_path }} bfasst/utils/sdn_helpers.py
     expect_fail = {{ expect_fail }}
 

--- a/bfasst/tools/compare/yosys/yosys.py
+++ b/bfasst/tools/compare/yosys/yosys.py
@@ -19,7 +19,7 @@ class YosysCompare(Tool):
         self.tcl_template = YOSYS_TOOLS_PATH / "yosys.tcl.mustache"
         self._init_outputs()
         self.rule_snippet_path = YOSYS_TOOLS_PATH / "yosys_rules.ninja.mustache"
-        self.render_dict = {"utils": str(BFASST_UTILS_PATH)}
+        self.rules_render_dict = {"utils": str(BFASST_UTILS_PATH)}
 
     def create_build_snippets(self):
         self.__write_json_file()

--- a/bfasst/tools/impl/vivado_impl.py
+++ b/bfasst/tools/impl/vivado_impl.py
@@ -26,7 +26,7 @@ class VivadoImpl(ImplTool):
         self._my_dir_path = pathlib.Path(__file__).parent
         self._init_outputs()
         self.rule_snippet_path = COMMON_TOOLS_PATH / "vivado_rules.ninja.mustache"
-        self.render_dict = {
+        self.rules_render_dict = {
             "vivado_path": config.VIVADO_BIN_PATH,
             "utils_path": BFASST_UTILS_PATH,
         }

--- a/bfasst/tools/rev_bit/xray.py
+++ b/bfasst/tools/rev_bit/xray.py
@@ -2,7 +2,14 @@
 
 import chevron
 from bfasst import config
-from bfasst.paths import NINJA_BUILD_PATH, REV_BIT_TOOLS_PATH, XRAY_PATH, get_fasm2bels_path
+from bfasst.paths import (
+    NINJA_BUILD_PATH,
+    REV_BIT_TOOLS_PATH,
+    XRAY_PATH,
+    FASM2BELS_PATH,
+    FASM2BELS_PYTHON_PATH,
+    XRAY_DB_PATH,
+)
 from bfasst.tools.tool import Tool
 
 
@@ -14,28 +21,14 @@ class Xray(Tool):
 
         self.xdc_input = xdc_input
         self.bitstream = bitstream
-
         self.build_path = self.design_build_path / "xray"
-
-        # get these moved to paths later
-        self.fasm2bels_path = get_fasm2bels_path()
-        self.fasm2bels_python_path = (
-            self.fasm2bels_path
-            / "env"
-            / "conda"
-            / "envs"
-            / "f4pga_xc_fasm2bels"
-            / "bin"
-            / "python3"
-        )
-        self.xray_db_path = self.fasm2bels_path / "third_party" / "prjxray-db"
-        self.db_root = self.xray_db_path / config.PART_FAMILY
         self.to_netlist_log = self.build_path / "to_netlist.log"
+
         self.fasm_path = self.build_path / (self.design_props.top + ".fasm")
         self.reversed_netlist_path = self.build_path / (self.design_props.top + "_reversed.v")
         self.xdc_path = self.build_path / (self.design_props.top + "_reversed.xdc")
-        self.rule_snippet_path = REV_BIT_TOOLS_PATH / "xray.ninja_rules"
 
+        self.rule_snippet_path = REV_BIT_TOOLS_PATH / "xray.ninja_rules"
         self._init_outputs()
 
     def create_build_snippets(self):
@@ -49,13 +42,13 @@ class Xray(Tool):
                     "rev_netlist": str(self.outputs["rev_netlist"]),
                     "xray_xdc": str(self.outputs["xray_xdc"]),
                     "bitstream_path": self.bitstream,
-                    "fasm2bels_path": self.fasm2bels_path,
-                    "fasm2bels_python_path": self.fasm2bels_python_path,
+                    "fasm2bels_path": FASM2BELS_PATH,
+                    "fasm2bels_python_path": FASM2BELS_PYTHON_PATH,
                     "bit_to_fasm_path": XRAY_PATH / "utils" / "bit2fasm.py",
-                    "db_root": self.db_root,
+                    "db_root": XRAY_DB_PATH / config.PART_FAMILY,
                     "part": config.PART,
                     "input_xdc": self.xdc_input,
-                    "db_marker": self.fasm2bels_path / "db_marker",
+                    "db_marker": FASM2BELS_PATH / "db_marker",
                 },
             )
 

--- a/bfasst/tools/synth/vivado_synth.py
+++ b/bfasst/tools/synth/vivado_synth.py
@@ -26,7 +26,7 @@ class VivadoSynth(SynthTool):
         # outputs must be initialized AFTER output paths are set
         self._init_outputs()
         self.rule_snippet_path = COMMON_TOOLS_PATH / "vivado_rules.ninja.mustache"
-        self.render_dict = {
+        self.rules_render_dict = {
             "vivado_path": config.VIVADO_BIN_PATH,
             "in_context": not self.ooc,
             "utils_path": BFASST_UTILS_PATH,

--- a/bfasst/tools/synth/vivado_synth_tcl.py
+++ b/bfasst/tools/synth/vivado_synth_tcl.py
@@ -16,7 +16,7 @@ class VivadoSynthFromTcl(Tool):
         self.build_path = self.design_build_path / "vivado_synth"
         self._init_outputs()
         self.rule_snippet_path = COMMON_TOOLS_PATH / "vivado_rules.ninja.mustache"
-        self.render_dict = {
+        self.rules_render_dict = {
             "vivado_path": config.VIVADO_BIN_PATH,
             "utils_path": BFASST_UTILS_PATH,
             "in_context": True,

--- a/bfasst/tools/tool.py
+++ b/bfasst/tools/tool.py
@@ -32,8 +32,8 @@ class ToolBase(abc.ABC):
         self.flow.rule_paths.append(rules_path)
 
         with open(rules_path, "r") as f:
-            if render_dict:
-                rules = chevron.render(f, render_dict)
+            if rules_render_dict:
+                rules = chevron.render(f, rules_render_dict)
             else:
                 rules = f.read()
 

--- a/bfasst/tools/tool.py
+++ b/bfasst/tools/tool.py
@@ -25,7 +25,7 @@ class ToolBase(abc.ABC):
     def create_rule_snippets(self):
         """Create the rule snippets for the flow and append them to build.ninja"""
         rules_path = self.rule_snippet_path if hasattr(self, "rule_snippet_path") else None
-        render_dict = self.render_dict if hasattr(self, "render_dict") else None
+        rules_render_dict = self.rules_render_dict if hasattr(self, "rules_render_dict") else None
         if rules_path in self.flow.rule_paths:
             return
 

--- a/bfasst/tools/transform/netlist_cleanup_build.ninja.mustache
+++ b/bfasst/tools/transform/netlist_cleanup_build.ninja.mustache
@@ -1,4 +1,4 @@
-build {{ netlist_out }} {{ netlist_cleanup_output }}/log.txt: netlist_cleanup {{ netlist_in }} | bfasst/utils/netlist_cleanup.py
+build {{ netlist_out }} {{ netlist_cleanup_output }}/log.txt: netlist_cleanup {{ netlist_in }} | bfasst/utils/netlist_cleanup.py bfasst/utils/sdn_helpers.py
     build_path = {{ netlist_cleanup_output }}
     netlist_in = {{ netlist_in }}
     netlist_out = {{ netlist_out }}

--- a/bfasst/utils/general.py
+++ b/bfasst/utils/general.py
@@ -212,9 +212,7 @@ def ensure_tuple(x):
 
 def ensure(x, y):
     """Compensates for how python deals with default reference objects"""
-    if x is None:
-        return y
-    return x
+    return x if x is not None else y
 
 
 def json_write_if_changed(path, json_str):

--- a/bfasst/utils/structural.py
+++ b/bfasst/utils/structural.py
@@ -392,7 +392,8 @@ class StructuralCompare:
                     if len(remaining) == len(reversed_remaining[0]):
                         for named, rev in zip(
                             set(self.named_netlist.instances_to_map), reversed_remaining[0]
-                        ):  # Make a copy of instances_to_map since python won't let you change the size of a set during iteration
+                        ):  # Make a copy of instances_to_map since python won't let you 
+                        # change the size of a set during iteration
                             self.add_block_mapping(named, rev)
                         break
 

--- a/bfasst/utils/structural.py
+++ b/bfasst/utils/structural.py
@@ -375,7 +375,7 @@ class StructuralCompare:
         while self.named_netlist.instances_to_map:
             if not overall_progress:
                 num_mapped_nets = (
-                    len([net for net in self.net_mapping if net.is_connected()])
+                    len([net for net in self.net_mapping if net.is_connected])
                     + len(self.vcc_mappings)
                     + len(self.gnd_mappings)
                 )
@@ -390,9 +390,7 @@ class StructuralCompare:
                         for j in i:
                             remaining.add(j.name)
                     if len(remaining) == len(reversed_remaining[0]):
-                        for named, rev in zip(
-                            self.named_netlist.instances_to_map, reversed_remaining[0]
-                        ):
+                        for named, rev in zip(set(self.named_netlist.instances_to_map), reversed_remaining[0]): # Make a copy of instances_to_map since python won't let you change the size of a set during iteration
                             self.add_block_mapping(named, rev)
                         break
 

--- a/bfasst/utils/structural.py
+++ b/bfasst/utils/structural.py
@@ -392,8 +392,8 @@ class StructuralCompare:
                     if len(remaining) == len(reversed_remaining[0]):
                         for named, rev in zip(
                             set(self.named_netlist.instances_to_map), reversed_remaining[0]
-                        ):  # Make a copy of instances_to_map since python won't let you 
-                        # change the size of a set during iteration
+                        ):  # Make a copy of instances_to_map since python won't let you
+                            # change the size of a set during iteration
                             self.add_block_mapping(named, rev)
                         break
 

--- a/bfasst/utils/structural.py
+++ b/bfasst/utils/structural.py
@@ -390,7 +390,9 @@ class StructuralCompare:
                         for j in i:
                             remaining.add(j.name)
                     if len(remaining) == len(reversed_remaining[0]):
-                        for named, rev in zip(set(self.named_netlist.instances_to_map), reversed_remaining[0]): # Make a copy of instances_to_map since python won't let you change the size of a set during iteration
+                        for named, rev in zip(
+                            set(self.named_netlist.instances_to_map), reversed_remaining[0]
+                        ):  # Make a copy of instances_to_map since python won't let you change the size of a set during iteration
                             self.add_block_mapping(named, rev)
                         break
 


### PR DESCRIPTION
- Added fasm2bels and xray paths to paths.py
- render_dict --> rules_render_dict to add some specificity
- weekly tests timeout 40 --> 60 minutes
- 2 small adjustments to perform_mapping in structural.py, fixing an issue that was causing weekly tests to fail
- added sdn_helpers as an implicit dependency for structural_comparison and netlist_cleanup

