### PR TITLE
remove rule to build itself

### DIFF
--- a/master.ninja.mustache
+++ b/master.ninja.mustache
@@ -1,11 +1,3 @@
-rule configure
-    command = python {{ FLOWS_PATH }}/ninja_flow_manager.py $flow $in --flow_arguments "$flow_arguments"
-    generator = 1
-
-build build.ninja: configure {{#designs}}{{ . }} {{/designs}} | {{#deps}}{{ . }} {{/deps}}
-    flow = {{ flow }}
-    flow_arguments = {{ flow_arguments }}
-
 rule template
     command = chevron -d $in >$out
 


### PR DESCRIPTION
Our first ninja rule in every file was to rebuild the master ninja build file. I think this caused the following:
![image](https://github.com/byuccl/bfasst/assets/50156344/148745ef-e747-4180-aa6f-47e04dfe85d7)
I'm pretty sure that ninja does not expect or handle the build file changing while it is executing it?
Ninjas job output "[jobs_complete/total_jobs]" for me seemed to be one less than the number of build statements in the file (for doing a single design). 
Anyway, I think once the build file was rewritten, ninja starts the build count over again. Also, sometimes it replaces the current line, so you do not notice that it is happening, and sometimes it creates a new line like shown in the image.