### PR TITLE
added caching mechanism

### DIFF
--- a/bfasst/flows/vivado_phys_netlist_cmp.py
+++ b/bfasst/flows/vivado_phys_netlist_cmp.py
@@ -13,11 +13,12 @@ from bfasst.tools.synth.vivado_synth import VivadoSynth
 class VivadoPhysNetlistCmp(Flow):
     """Structural Comparison of physical netlist and reversed netlist"""
 
-    def __init__(self, design, synth_options=""):
+    def __init__(self, design, synth_options="", debug=False):
         # pylint: disable=duplicate-code
         super().__init__(design)
 
         self.synth_options = VivadoPhysNetlist.add_required_synth_options(synth_options)
+        self.debug = debug
 
         self.vivado_synth_tool = VivadoSynth(self, design, synth_options=self.synth_options)
         self.vivado_impl_tool = VivadoImpl(
@@ -44,6 +45,7 @@ class VivadoPhysNetlistCmp(Flow):
             "struct_cmp.log",
             golden_netlist=self.phys_netlist_tool.outputs["viv_impl_physical_v"],
             rev_netlist=self.xray_tool.outputs["rev_netlist"],
+            debug=self.debug,
         )
         # pylint: enable=duplicate-code
 

--- a/bfasst/tools/compare/structural/structural.py
+++ b/bfasst/tools/compare/structural/structural.py
@@ -8,7 +8,14 @@ class Structural(Tool):
     """Create the rule and build snippets for structural comparison."""
 
     def __init__(
-        self, flow, design, log_name=None, golden_netlist=None, rev_netlist=None, expect_fail=False
+        self,
+        flow,
+        design,
+        log_name=None,
+        golden_netlist=None,
+        rev_netlist=None,
+        expect_fail=False,
+        debug=False,
     ):
         super().__init__(flow, design)
         self.build_path = self.design_build_path / "struct_cmp"
@@ -16,6 +23,7 @@ class Structural(Tool):
         self.golden_netlist = golden_netlist
         self.rev_netlist = rev_netlist
         self.expect_fail = expect_fail
+        self.debug = debug
         self._init_outputs()
         self.rule_snippet_path = COMPARE_TOOLS_PATH / "structural" / "structural_rules.ninja"
 
@@ -28,6 +36,7 @@ class Structural(Tool):
                 "log_path": str(self.outputs["structural_log"]),
                 "compare_script_path": str(BFASST_UTILS_PATH / "structural.py"),
                 "expect_fail": "--expect_fail" if self.expect_fail else "",
+                "debug": "--debug True" if self.debug else "",
             },
         )
 

--- a/bfasst/tools/compare/structural/structural_build.ninja.mustache
+++ b/bfasst/tools/compare/structural/structural_build.ninja.mustache
@@ -1,3 +1,5 @@
 build {{ log_path }}: compare {{ netlist_a }} {{ netlist_b }} | {{ compare_script_path }} bfasst/utils/sdn_helpers.py
     expect_fail = {{ expect_fail }}
+    debug = {{ debug }}
+
 

--- a/bfasst/tools/compare/structural/structural_rules.ninja
+++ b/bfasst/tools/compare/structural/structural_rules.ninja
@@ -1,4 +1,4 @@
 rule compare
-    command = python bfasst/utils/structural.py --netlists $in --log_path $out $expect_fail
+    command = python bfasst/utils/structural.py --netlists $in --log_path $out $expect_fail $debug
     description = structurally compare $in
 

--- a/bfasst/utils/structural.py
+++ b/bfasst/utils/structural.py
@@ -30,7 +30,7 @@ class StructuralCompareError(Exception):
 class StructuralCompare:
     """Structural compare and map"""
 
-    def __init__(self, named_netlist_path, reversed_netlist_path, log_path, debug=False) -> None:
+    def __init__(self, named_netlist_path, reversed_netlist_path, log_path, debug) -> None:
         self.reversed_netlist_path = reversed_netlist_path
         self.named_netlist_path = named_netlist_path
         self.named_netlist = None
@@ -863,11 +863,13 @@ if __name__ == "__main__":
     )
     parser.add_argument("--log_path", type=str, help="The log file path to use as output")
     parser.add_argument("--expect_fail", action="store_true", help="Expect the comparison to fail")
+    parser.add_argument("--debug", help="Utilize debugging functionality")
     args = parser.parse_args()
     struct_cmp = StructuralCompare(
         named_netlist_path=args.netlists[0],
         reversed_netlist_path=args.netlists[1],
         log_path=args.log_path,
+        debug=args.debug,
     )
     try:
         struct_cmp.compare_netlists()

--- a/bfasst/utils/structural.py
+++ b/bfasst/utils/structural.py
@@ -383,14 +383,9 @@ class StructuralCompare:
                     )
 
                 self.possible_matches[named_instance] = instances_matching.copy()
-
             possible_matches = {}
-            # pylint: disable=consider-using-dict-items
-            for named_instance in self.possible_matches:
-                possible_matches[named_instance.name] = [
-                    i.name for i in self.possible_matches[named_instance]
-                ]
-            # pylint: enable=consider-using-dict-items
+            for named_instance, possibilities in self.possible_matches.items():
+                possible_matches[named_instance.name] = [i.name for i in possibilities]
             with open(possible_matches_cache_path, "wb") as f:
                 pickle.dump(possible_matches, f)
 

--- a/bfasst/utils/structural.py
+++ b/bfasst/utils/structural.py
@@ -777,8 +777,6 @@ class StructuralCompare:
             i for i in self.possible_matches[named_instance] if i not in self.block_mapping.inverse
         ]
 
-        pin_causing_failure = None
-
         for pin in named_instance.pins:
             # Skip pin that is not yet mapped
             if pin.net not in self.net_mapping:
@@ -836,8 +834,6 @@ class StructuralCompare:
                 else ""
             )
             logging.info("    %s remaining%s", num_instances, info)
-            if not num_instances and not pin_causing_failure:
-                pin_causing_failure = pin
 
         logging.info(
             "  %s instance(s) after filtering on connections", len(instances_matching_connections)

--- a/bfasst/utils/structural.py
+++ b/bfasst/utils/structural.py
@@ -23,11 +23,14 @@ class StructuralCompareError(Exception):
 class StructuralCompare:
     """Structural compare and map"""
 
-    def __init__(self, named_netlist_path, reversed_netlist_path, log_path) -> None:
+    def __init__(
+        self, named_netlist_path, reversed_netlist_path, log_path, use_cache=False
+    ) -> None:
         self.reversed_netlist_path = reversed_netlist_path
         self.named_netlist_path = named_netlist_path
         self.named_netlist = None
         self.reversed_netlist = None
+        self.use_cache = use_cache
 
         self.log_path = log_path
         logging.basicConfig(
@@ -279,14 +282,15 @@ class StructuralCompare:
     def init_matching_instances(self):
         """Init possible_matches dict with all instances that match by cell type and properties"""
         log_with_banner("Initializing possible matches based on cell type and properties")
-        possible_matches_cache_path = os.path.join(
-            os.path.dirname(self.log_path), "possible_matches.pkl"
-        )
-        if os.path.exists(possible_matches_cache_path):
-            logging.info("Loading possible matches from cache")
-            with open(possible_matches_cache_path, "rb") as f:
-                pickle_dump = pickle.load(f)
-                self.import_possible_matches(pickle_dump)
+        if self.use_cache:
+            possible_matches_cache_path = os.path.join(
+                os.path.dirname(self.log_path), "possible_matches.pkl"
+            )
+            if os.path.exists(possible_matches_cache_path):
+                logging.info("Loading possible matches from cache")
+                with open(possible_matches_cache_path, "rb") as f:
+                    pickle_dump = pickle.load(f)
+                    self.import_possible_matches(pickle_dump)
 
         else:
             all_instances = [
@@ -345,8 +349,9 @@ class StructuralCompare:
                     i.name for i in self.possible_matches[named_instance]
                 ]
             # pylint: enable=consider-using-dict-items
-            with open(possible_matches_cache_path, "wb") as f:
-                pickle.dump(possible_matches, f)
+            if self.use_cache:
+                with open(possible_matches_cache_path, "wb") as f:
+                    pickle.dump(possible_matches, f)
 
     def import_possible_matches(self, pickle_dump):
         all_instances = {

--- a/bfasst/utils/structural.py
+++ b/bfasst/utils/structural.py
@@ -16,7 +16,11 @@ from bfasst import jpype_jvm
 from bfasst.utils import convert_verilog_literal_to_int
 from bfasst.utils.general import log_with_banner
 from bfasst.utils.sdn_helpers import SdnNetlistWrapper, SdnInstanceWrapper, SdnNet, SdnPinWrapper
+
+# pylint: disable=wrong-import-order
 from com.xilinx.rapidwright.design import Design
+
+# pylint: enable=wrong-import-order
 
 
 class StructuralCompareError(Exception):
@@ -26,9 +30,7 @@ class StructuralCompareError(Exception):
 class StructuralCompare:
     """Structural compare and map"""
 
-    def __init__(
-        self, named_netlist_path, reversed_netlist_path, log_path, debug=False
-    ) -> None:
+    def __init__(self, named_netlist_path, reversed_netlist_path, log_path, debug=False) -> None:
         self.reversed_netlist_path = reversed_netlist_path
         self.named_netlist_path = named_netlist_path
         self.named_netlist = None
@@ -433,7 +435,8 @@ class StructuralCompare:
                             instance.name, [cell.getName() for cell in cells], n=1
                         )[0]
                     )
-                    # now that we have the cell's actual name, we can use that to access the cell object
+                    # now that we have the cell's actual name,
+                    # we can use that to access the cell object
                     cell = [cell for cell in cells if cell.getName() == actual_cell_name][0]
 
                 site = cell.getSite()


### PR DESCRIPTION
For the larger designs like jpegencode, a lot of the runtime is spent initializing the list of possible matches for each primitive based on cell type and properties. This pr creates a caching mechanism which rebuilds the dict based on the instance names. For jpegencode, this brought the runtime down by 29 minutes. 