### PR TITLE
check for system verilog files in design.yaml

### DIFF
--- a/bfasst/design.py
+++ b/bfasst/design.py
@@ -110,6 +110,9 @@ class Design:
             "verilog_files": lambda value: self.verilog_file_paths.extend(
                 self.path / source for source in value
             ),
+            "system_verilog_files": lambda value: self.system_verilog_file_paths.extend(
+                self.path / source for source in value
+            ),
             "vhdl_libs": lambda value: setattr(self, "vhdl_libs", self.enum_vhdl_libs(value)),
         }
 

--- a/bfasst/tools/synth/synth_tool.py
+++ b/bfasst/tools/synth/synth_tool.py
@@ -36,6 +36,13 @@ class SynthTool(Tool):
             self.verilog = [
                 str(self.design_path / file) for file in self.design_props.verilog_files
             ]
+
+        if self.design_props.system_verilog_files is not None:
+            self.system_verilog = [
+                str(self.design_path / file) for file in self.design_props.system_verilog_files
+            ]
+
+        if self.verilog or self.system_verilog:
             return
 
         for child in self.design_path.rglob("*"):

--- a/bfasst/yaml_parser.py
+++ b/bfasst/yaml_parser.py
@@ -91,6 +91,7 @@ class DesignParser(YamlParser):
         self.top = None
         self.vhdl_libs = None
         self.verilog_files = None
+        self.system_verilog_files = None
         self.clocks = {}
         self.part = config.PART
 
@@ -110,6 +111,9 @@ class DesignParser(YamlParser):
 
         if "verilog_files" in props:
             self.verilog_files = props["verilog_files"]
+
+        if "system_verilog_files" in props:
+            self.system_verilog_files = props["system_verilog_files"]
 
 
 class FlowDescriptionParser(YamlParser):

--- a/designs/ooc/mpeg2fpga/design.yaml
+++ b/designs/ooc/mpeg2fpga/design.yaml
@@ -1,5 +1,8 @@
 top: mpeg2fpga_random
 
+system_verilog_files:
+  - mpeg2fpga_random.sv
+
 verilog_files:
   # - fifo_size.v
   - framestore_request.v


### PR DESCRIPTION
If in the design.yaml file, there was a "verilog_files:" property, system verilog files were not being checked for at all, which causes a missing module in one of the weekly tests
