### PR TITLE
fasm2bels parts db

### DIFF
--- a/bfasst/tools/rev_bit/xray.ninja_build.mustache
+++ b/bfasst/tools/rev_bit/xray.ninja_build.mustache
@@ -1,11 +1,11 @@
-build {{ xray_fasm }}: bit_to_fasm {{ bitstream_path }} | {{ db_marker }}
+build {{ xray_fasm }}: bit_to_fasm {{ bitstream_path }}
     xray_path = {{ xray_path }}
     fasm2bels_python_path = {{ fasm2bels_python_path }}
     bit_to_fasm_path = {{ bit_to_fasm_path }}
     db_root = {{ db_root }}
     part = {{ part }}
 
-build {{ rev_netlist }} {{ xray_xdc }}: fasm_to_netlist {{ xray_fasm }} | {{ db_marker }}
+build {{ rev_netlist }} {{ xray_xdc }}: fasm_to_netlist {{ xray_fasm }}
     fasm2bels_path = {{ fasm2bels_path }}
     fasm2bels_python_path = {{ fasm2bels_python_path }}
     part_db = {{ part }}_db

--- a/bfasst/tools/rev_bit/xray.py
+++ b/bfasst/tools/rev_bit/xray.py
@@ -48,7 +48,6 @@ class Xray(Tool):
                     "db_root": XRAY_DB_PATH / config.PART_FAMILY,
                     "part": self.flow.part,
                     "input_xdc": self.xdc_input,
-                    "db_marker": FASM2BELS_PATH / "db_marker",
                 },
             )
 

--- a/scripts/install-fasm2bels.sh
+++ b/scripts/install-fasm2bels.sh
@@ -11,7 +11,7 @@ then
 fi
 
 # Check if submodule path
-if [ ${BFASST_PATH_FASM2BELS} == "third_party/fasm2bels" ]
+if [ "${BFASST_PATH_FASM2BELS}" == "third_party/fasm2bels" ]
 then
     USE_SUBMODULE=true
     git submodule init third_party/fasm2bels
@@ -20,10 +20,15 @@ else
     USE_SUBMODULE=false
 fi
 
+if [ -z "${FASM2BELS_PYTHON_PATH}" ]
+then 
+    FASM2BELS_PYTHON_PATH="${BFASST_PATH_FASM2BELS}/env/conda/envs/f4pga_xc_fasm2bels/bin/python3"
+fi
+
 # Check if cache file matches current commit.  Will return "-" if submodule
 # has not been initialized, so need to remove it.
 FASM2BELS_COMMIT=$(git submodule status third_party/fasm2bels/ | awk '{print $1}')
-if [ ${FASM2BELS_COMMIT::1} = "-" ]
+if [ "${FASM2BELS_COMMIT::1}" = "-" ]
 then
     FASM2BELS_COMMIT=${FASM2BELS_COMMIT:1}
 fi
@@ -31,32 +36,29 @@ fi
 FASM2BELS_URL=$(git config --file .gitmodules submodule.third_party/fasm2bels.url)
 echo "Need fasm2bels version: ${FASM2BELS_URL} ${FASM2BELS_COMMIT}"
     
-if [ -f ${BFASST_PATH_FASM2BELS}/fasm2bels_commit.txt ] && [ $FASM2BELS_COMMIT == $(cat ${BFASST_PATH_FASM2BELS}/fasm2bels_commit.txt) ] ; then
+if [ -f "${BFASST_PATH_FASM2BELS}/fasm2bels_commit.txt" ] && [ "${FASM2BELS_COMMIT}" == "$(cat ${BFASST_PATH_FASM2BELS}/fasm2bels_commit.txt)" ] ; then
     # Successful cache, do nothing
-    touch ${BFASST_PATH_FASM2BELS}/"db_marker"
     echo "Found cached version of fasm2bels. No install required."
 else
-    echo Installing new version of fasm2bels at ${BFASST_PATH_FASM2BELS}. This will be cached for future use.
-    rm -rf ${BFASST_PATH_FASM2BELS}/fasm2bels_commit.txt
+    echo "Installing new version of fasm2bels at ${BFASST_PATH_FASM2BELS}. This will be cached for future use."
+    rm -rf "${BFASST_PATH_FASM2BELS}/fasm2bels_commit.txt"
     
-    if [ ${USE_SUBMODULE} = true ] ; then
+    if [ "${USE_SUBMODULE}" = true ] ; then
         git submodule update --recursive third_party/fasm2bels
     else
-        rm -rf ${BFASST_PATH_FASM2BELS}
-	    git clone ${FASM2BELS_URL} ${BFASST_PATH_FASM2BELS}
-	    cd ${BFASST_PATH_FASM2BELS} && git reset --hard ${FASM2BELS_COMMIT} && cd -
+        rm -rf "${BFASST_PATH_FASM2BELS}"
+        git clone "${FASM2BELS_URL}" "${BFASST_PATH_FASM2BELS}"
+        cd "${BFASST_PATH_FASM2BELS}" && git reset --hard "${FASM2BELS_COMMIT}" && cd -
     fi
 
-	cd ${BFASST_PATH_FASM2BELS}
+    cd "${BFASST_PATH_FASM2BELS}"
     make env
-	make build
-	make test-py
+    make build
+    make test-py
     cd -
 
-    # Run a design to generate the part database
-    touch ${BFASST_PATH_FASM2BELS}/"db_marker"
-    python scripts/run.py VivadoBitToNetlist designs/basic/and3 --no_tool_checks
+    # Generate the part db to cache
+    "${FASM2BELS_PYTHON_PATH}" "${BFASST_PATH_FASM2BELS}/fasm2bels/database/create_channels.py" --db-root "${BFASST_PATH_FASM2BELS}/third_party/prjxray-db/artix7" --part "xc7a200tsbg484-1" --connection-database-output "${BFASST_PATH_FASM2BELS}/xc7a200tsbg484-1_db"
 
-    echo $FASM2BELS_COMMIT > ${BFASST_PATH_FASM2BELS}/fasm2bels_commit.txt
+    echo "${FASM2BELS_COMMIT}" > "${BFASST_PATH_FASM2BELS}/fasm2bels_commit.txt"
 fi
-


### PR DESCRIPTION
Instead of running fasm2bels on the basic/and3 design, I directly invoke the fasm2bels command which generates the db. This means we skip synthesis, implementation, and all the other unnecessary steps we were doing before, and now we don't have to worry about the situation in which ninja gives the message "no work to do" if we already ran the fasm2bels flow on basic/and3 earlier.
