### PR TITLE
weekly timeout

### DIFF
--- a/.github/workflows/weeklytests.yml
+++ b/.github/workflows/weeklytests.yml
@@ -43,7 +43,7 @@ jobs:
         make env
         . .venv/bin/activate && python bfasst/external_tools.py install_test_yaml ${{ matrix.experiment }}
     - name: tests
-      timeout-minutes: 60
+      timeout-minutes: 240
       run: |
         source .venv/bin/activate
         python scripts/run.py ${{ matrix.experiment }}


### PR DESCRIPTION
I want to see the weekly tests all finish. RandSoc keeps timing out which cancels the rest
