### PR TITLE
Check logging for f-strings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -451,7 +451,7 @@ min-public-methods=2
 
 # The type of string formatting that logging methods do. `old` means using %
 # formatting, `new` is for `{}` formatting.
-logging-format-style=new
+logging-format-style=old
 
 # Logging modules to check that the string format arguments are in logging
 # function parameter format.

--- a/.pylintrc
+++ b/.pylintrc
@@ -451,7 +451,7 @@ min-public-methods=2
 
 # The type of string formatting that logging methods do. `old` means using %
 # formatting, `new` is for `{}` formatting.
-logging-format-style=old
+logging-format-style=new
 
 # Logging modules to check that the string format arguments are in logging
 # function parameter format.

--- a/codingstandard.md
+++ b/codingstandard.md
@@ -15,7 +15,7 @@ Note that this is subject to change and discussion.
 + Maximum of 15 locals per function.
 + No else after return statement.
 + Run all code through black.
-+ For string generation, use f-strings.
++ For string generation, use f-strings - except for [logging](https://docs.python.org/3/howto/logging.html#optimization)
 + If a file has a main, the main should take no arguments, parse the argv, and only call another function.
 + If comparing against a singleton object (`True`, `False`, `None`), use `is` instead of `==`, `is not` instead of `!=`.
 + For parsing system parameters, use argparse


### PR DESCRIPTION
The logging library functions allow for kwargs to process "%" strings. Our coding style is f-strings, and this will have pylint check the logging calls to enforce this.