### PR TITLE
cleanup

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: 'Upload artifacts'
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.set-fname.outputs.fname }}
         path: |

--- a/.github/workflows/weeklytests.yml
+++ b/.github/workflows/weeklytests.yml
@@ -53,7 +53,7 @@ jobs:
       run: echo "fname=$(basename ${{ matrix.experiment }} .yaml)" >> $GITHUB_OUTPUT
     - name: 'Upload artifacts'
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.set-fname.outputs.fname }}
         path: |

--- a/bfasst/utils/netlist_cleanup.py
+++ b/bfasst/utils/netlist_cleanup.py
@@ -43,7 +43,7 @@ class NetlistCleaner:
         logging.info("Finding and removing all ASSIGN instances")
         t_begin = time.perf_counter()
         for instance in top.get_instances():
-            if instance.reference.name.startswith("SDN_VERILOG_ASSIGNMENT"):
+            if instance.reference.name.startswith("SD"):
                 pin_out = None
 
                 for pin in instance.pins:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pylint
 pyyaml
 requests
 scp
-spydrnet @ git+https://github.com/byuccl/spydrnet@next_release
+spydrnet @ git+https://github.com/byuccl/spydrnet@bfasst_spydrnet
 werkzeug
 boolean.py
 xlsxwriter


### PR DESCRIPTION
- Bumped spydrnet to a new branch which doesn't rename constant nets, we already have logic to deal with that in bfasst and the spydrnet method for renaming the constants is extremely slow.

- Use remove_children_from instead of remove_child function in the cleaner. The remove_child function has extremely slow repeated list removal operations. remove_children_from creates a copy of the list with the children that need to be removed excluded, which ends up being much faster.  

For reference, in the main branch, it took jpegencode 204 minutes (3 hrs 24 minutes) to clean. On this branch, it took 26.5 minutes.
