### PR TITLE
Rm template io

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -89,10 +89,6 @@ py-version=3.8
 # Discover python modules and packages in the file system subtree.
 recursive=no
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/bfasst/tools/common/vivado_rules.ninja.mustache
+++ b/bfasst/tools/common/vivado_rules.ninja.mustache
@@ -1,5 +1,5 @@
 rule vivado
-    command = cd $cwd && {{ utils_path }}/retry.sh {{ vivado_path }} -mode batch -journal $journal -log $log -source $in > /dev/null
+    command = cd $cwd && {{ vivado_path }} -mode batch -journal $journal -log $log -source $in > /dev/null
     description = vivado $in
 
 {{#in_context}}

--- a/bfasst/tools/common/vivado_rules.ninja.mustache
+++ b/bfasst/tools/common/vivado_rules.ninja.mustache
@@ -1,5 +1,5 @@
 rule vivado
-    command = cd $cwd && {{ utils_path }}/retry.sh {{ vivado_path }} -mode batch -journal $journal -log $log -source $in >&- 
+    command = cd $cwd && {{ utils_path }}/retry.sh {{ vivado_path }} -mode batch -journal $journal -log $log -source $in > /dev/null
     description = vivado $in
 
 {{#in_context}}

--- a/bfasst/tools/compare/yosys/yosys.py
+++ b/bfasst/tools/compare/yosys/yosys.py
@@ -1,6 +1,5 @@
 """Create the rule and build snippets for yosys comparison."""
 
-import json
 from bfasst.tools.tool import Tool
 from bfasst.paths import BFASST_UTILS_PATH, YOSYS_TOOLS_PATH
 from bfasst.utils.general import json_write_if_changed
@@ -32,9 +31,7 @@ class YosysCompare(Tool):
             "gold_netlist": str(self.golden_netlist),
             "rev_netlist": str(self.rev_netlist),
         }
-        yosys_json = json.dumps(yosys_tcl_args, indent=4)
-
-        json_write_if_changed(self.outputs["yosys_json"], yosys_json)
+        json_write_if_changed(self.outputs["yosys_json"], yosys_tcl_args)
 
     def __append_build_snippets(self):
         """Create ninja snippets for yosys comparison."""

--- a/bfasst/tools/impl/impl_detailed_reports.py
+++ b/bfasst/tools/impl/impl_detailed_reports.py
@@ -1,6 +1,5 @@
 """Tool to create Vivado implementation‐report ninja snippets."""
 
-import json
 import pathlib
 from bfasst import config
 from bfasst.tools.impl.impl_tool import ImplTool
@@ -64,8 +63,7 @@ class ImplDetailedReports(ImplTool):
         self.outputs["log"] = bp / "vivado.log"
 
     def create_build_snippets(self):
-        rpt_json = json.dumps(self.report_build, indent=4)
-        json_write_if_changed(self.build_path / "reports.json", rpt_json)
+        json_write_if_changed(self.build_path / "reports.json", self.report_build)
 
         self._append_build_snippets_default(
             __file__,

--- a/bfasst/tools/impl/vivado_impl.py
+++ b/bfasst/tools/impl/vivado_impl.py
@@ -1,6 +1,5 @@
 """Tool to create Vivado implementation ninja snippets."""
 
-import json
 import pathlib
 
 from bfasst import config
@@ -11,6 +10,14 @@ from bfasst.utils.general import ensure_tuple, json_write_if_changed
 
 class VivadoImpl(ImplTool):
     """Tool to create Vivado implementation ninja snippets."""
+
+    _my_dir_path = pathlib.Path(__file__).parent
+    template_tuples = [
+        (COMMON_TOOLS_PATH / "vivado_top_tcl.mustache", "run.tcl"),
+        (_my_dir_path / "vivado_impl_run.tcl.mustache", "impl.tcl"),
+        (_my_dir_path / "vivado_impl_setup.tcl.mustache", "setup.tcl"),
+        (_my_dir_path / "vivado_impl_reports.tcl.mustache", "reports.tcl"),
+    ]
 
     def __init__(
         self,
@@ -79,8 +86,11 @@ class VivadoImpl(ImplTool):
 
     def create_build_snippets(self):
         """Create build snippets in ninja file"""
-        impl_json = json.dumps(self.impl_build, indent=4)
-        json_write_if_changed(self.build_path / "impl.json", impl_json)
+        rerender, normalized_data = json_write_if_changed(
+            self.build_path / "impl.json", self.impl_build
+        )
+        if rerender:
+            self._render_templates(self.build_path, VivadoImpl.template_tuples, normalized_data)
 
         self._append_build_snippets_default(
             __file__,

--- a/bfasst/tools/impl/vivado_impl_build.ninja.mustache
+++ b/bfasst/tools/impl/vivado_impl_build.ninja.mustache
@@ -1,9 +1,3 @@
-{{#outputs.clock_crank_tcl}}build {{.}}: template {{outputs.impl_json}} {{impl_library}}/clock_crank.tcl.mustache {{/outputs.clock_crank_tcl}}
-build {{outputs.setup_tcl}}: template {{outputs.impl_json}} {{impl_library}}/vivado_impl_setup.tcl.mustache
-build {{outputs.impl_tcl}}: template {{outputs.impl_json}} {{impl_library}}/vivado_impl_run.tcl.mustache
-build {{outputs.reports_tcl}}: template {{outputs.impl_json}} {{impl_library}}/vivado_impl_reports.tcl.mustache
-build {{outputs.run_tcl}}: template {{outputs.impl_json}} {{common_tools_path }}/vivado_top_tcl.mustache | {{#tcl_sources}} {{.}} {{/tcl_sources}}
-
 build {{outputs.impl_verilog }} {{outputs.impl_edf}} {{outputs.impl_dcp}} {{outputs.bitstream }} {{outputs.utilization}}: vivado {{outputs.run_tcl}} {{inputs.synth_edf}} | {{#inputs.xdc}} {{ . }} {{/inputs.xdc}} {{#outputs.clock_crank_tcl}} {{.}} {{/outputs.clock_crank_tcl}} {{outputs.setup_tcl}} {{outputs.impl_tcl}} {{outputs.reports_tcl}}
     journal = {{outputs.journal}}
     log = {{outputs.log}}

--- a/bfasst/tools/synth/ic2_lse_synth.py
+++ b/bfasst/tools/synth/ic2_lse_synth.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=duplicate-code
 
-import json
 import pathlib
 from bfasst.config import (
     IC2_FOUNDRY,
@@ -43,8 +42,7 @@ class Ic2LseSynth(SynthTool):
             "top": self.design_props.top,
             "edf_output": str(self.outputs["edif_file"]),
         }
-        synth_json = json.dumps(synth, indent=4)
-        json_write_if_changed(self.outputs["synth_json"], synth_json)
+        json_write_if_changed(self.outputs["synth_json"], synth)
 
         # then the build snippet can be created as normal
         self._append_build_snippets_default(

--- a/bfasst/tools/synth/ic2_synplify_synth.py
+++ b/bfasst/tools/synth/ic2_synplify_synth.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=duplicate-code
 
-import json
 import pathlib
 from bfasst.config import (
     IC2_SYNPLIFY_LD_LIBRARY_PATH,
@@ -42,8 +41,7 @@ class Ic2SynplifySynth(SynthTool):
             "top": self.design_props.top,
             "edf_output": str(self.outputs["edf_output"]),
         }
-        synth_json = json.dumps(synth, indent=4)
-        json_write_if_changed(self.outputs["synth_json"], synth_json)
+        json_write_if_changed(self.outputs["synth_json"], synth)
 
         # then the build snippet can be created as normal
         self._append_build_snippets_default(

--- a/bfasst/tools/synth/vivado_synth.py
+++ b/bfasst/tools/synth/vivado_synth.py
@@ -1,6 +1,5 @@
 """Tool to create Vivado synthesis ninja snippets."""
 
-import json
 import pathlib
 
 from bfasst import config
@@ -11,6 +10,14 @@ from bfasst.utils.general import json_write_if_changed
 
 class VivadoSynth(SynthTool):
     """Tool to create vivado synthesis ninja snippets."""
+
+    _my_dir_path = pathlib.Path(__file__).parent
+    template_tuples = [
+        (COMMON_TOOLS_PATH / "vivado_top_tcl.mustache", "run.tcl"),
+        (_my_dir_path / "vivado_synth_setup.tcl.mustache", "setup.tcl"),
+        (_my_dir_path / "vivado_synth_run.tcl.mustache", "synth.tcl"),
+        (_my_dir_path / "vivado_synth_reports.tcl.mustache", "reports.tcl"),
+    ]
 
     def __init__(
         self, flow, design_path, synth_options="", opt_design=False, ooc=False
@@ -66,12 +73,12 @@ class VivadoSynth(SynthTool):
     def create_build_snippets(self):
         """Create build snippets in ninja file"""
 
-        # Specify synthesis arguments in a json file.
-        # Chevron will use this file to fill in the tcl template.
+        rerender, normalized_data = json_write_if_changed(
+            self.outputs["synth_json"], self.synth_build
+        )
 
-        synth_json = json.dumps(self.synth_build, indent=4)
-
-        json_write_if_changed(self.outputs["synth_json"], synth_json)
+        if rerender:  # Only re-render tcl files if the data has changed.
+            self._render_templates(self.build_path, VivadoSynth.template_tuples, normalized_data)
 
         self._append_build_snippets_default(
             __file__,

--- a/bfasst/tools/synth/vivado_synth_build.ninja.mustache
+++ b/bfasst/tools/synth/vivado_synth_build.ninja.mustache
@@ -2,7 +2,7 @@
 build {{ outputs.synth_constraints }}: vivado_ioparse {{ outputs.io_report }} | {{outputs.synth_dcp}}
 {{/in_context}}
 
-build {{ outputs.synth_edf }} {{ outputs.synth_dcp }} {{#in_context}}{{ outputs.io_report }}{{/in_context}}: vivado {{ outputs.run_tcl }} | {{#verilog}}{{ . }} {{/verilog}} {{#system_verilog}}{{ . }} {{/system_verilog}} {{#other_sources}}{{ . }} {{/other_sources}} {{outputs.setup_tcl}} {{outputs.synth_tcl}} {{outputs.reports_tcl}}
+build {{ outputs.synth_edf }} {{ outputs.synth_dcp }} {{#in_context}}{{ outputs.io_report }}{{/in_context}}: vivado {{ outputs.run_tcl }} | {{#verilog}}{{ . }} {{/verilog}} {{#system_verilog}}{{ . }} {{/system_verilog}} {{#other_sources}}{{ . }} {{/other_sources}} {{#tcl_sources}} {{ . }} {{/tcl_sources}}
     journal = {{ outputs.journal }}
     log = {{ outputs.log }}
     cwd = {{ cwd }}

--- a/bfasst/tools/synth/vivado_synth_build.ninja.mustache
+++ b/bfasst/tools/synth/vivado_synth_build.ninja.mustache
@@ -1,8 +1,3 @@
-{{#outputs.setup_tcl}}build {{.}}: template {{outputs.synth_json}} {{synth_library}}/vivado_synth_setup.tcl.mustache {{/outputs.setup_tcl}}
-{{#outputs.synth_tcl}}build {{.}}: template {{outputs.synth_json}} {{synth_library}}/vivado_synth_run.tcl.mustache {{/outputs.synth_tcl}}
-{{#outputs.reports_tcl}}build {{.}}: template {{outputs.synth_json}} {{synth_library}}/vivado_synth_reports.tcl.mustache {{/outputs.reports_tcl}}
-{{#outputs.run_tcl}}build {{.}}: template {{outputs.synth_json}} {{ common_tools_path }}/vivado_top_tcl.mustache | {{#tcl_sources}}{{ . }} {{/tcl_sources}} {{/outputs.run_tcl}}
-
 {{#in_context}}
 build {{ outputs.synth_constraints }}: vivado_ioparse {{ outputs.io_report }} | {{outputs.synth_dcp}}
 {{/in_context}}

--- a/bfasst/tools/synth/yosys_synth.py
+++ b/bfasst/tools/synth/yosys_synth.py
@@ -1,6 +1,5 @@
 """Tool to create Yosys synthesis ninja snippets."""
 
-import json
 import pathlib
 
 from bfasst.paths import YOSYS_EXE_PATH, YOSYS_SYNTH_SCRIPT_TEMPLATE, TOOLS_PATH
@@ -28,8 +27,7 @@ class YosysSynth(SynthTool):
             "vhdl": self.vhdl,
             "netlist": str(self.outputs["netlist"]),
         }
-        synth_json = json.dumps(synth, indent=4)
-        json_write_if_changed(self.outputs["synth_json"], synth_json)
+        json_write_if_changed(self.outputs["synth_json"], synth)
 
         # then the build snippet can be created as normal
         self._append_build_snippets_default(

--- a/bfasst/tools/tool.py
+++ b/bfasst/tools/tool.py
@@ -4,8 +4,8 @@ import abc
 import pathlib
 
 import chevron
-from bfasst.flows.flow import FlowBase
 
+from bfasst.flows.flow import FlowBase
 from bfasst.paths import BUILD_PATH, DESIGNS_PATH, NINJA_BUILD_PATH, ROOT_PATH
 from bfasst.yaml_parser import DesignParser
 
@@ -54,6 +54,20 @@ class ToolBase(abc.ABC):
     def _init_outputs(self):
         """Fill the self.outputs dictionary that lists
         all files the tool is responsible for creating"""
+
+    def _render_templates(self, build_dir, template_tuples, render_dict):
+        """
+        Helper function to render a list of templates with a given render dict
+
+        Only re-render when necessary to avoid all downstream targets from being out of date.
+        """
+        for template_path, output_path in template_tuples:
+            dest = build_dir / output_path
+            if not dest.is_file() or template_path.stat().st_mtime > dest.stat().st_mtime:
+                with open(template_path, "r") as f:
+                    rendered = chevron.render(f, render_dict)
+                with open(build_dir / output_path, "w") as f:
+                    f.write(rendered)
 
     def _append_build_snippets_default(self, py_tool_path, render_dict):
         """Create the build snippets for a python tool,

--- a/bfasst/tools/transform/phys_netlist.py
+++ b/bfasst/tools/transform/phys_netlist.py
@@ -1,7 +1,5 @@
 """Create rule and build snippets for phys netlist creation."""
 
-import json
-
 import chevron
 
 from bfasst.paths import BFASST_UTILS_PATH, NINJA_BUILD_PATH, NINJA_TRANSFORM_TOOLS_PATH
@@ -49,8 +47,7 @@ class PhysNetlist(Tool):
             "phys_netlist_checkpoint": str(self.outputs["phys_netlist_checkpoint"]),
         }
 
-        checkpoint_to_v_json = json.dumps(checkpoint_to_v, indent=4)
-        json_write_if_changed(self.outputs["checkpoint_to_v_json"], checkpoint_to_v_json)
+        json_write_if_changed(self.outputs["checkpoint_to_v_json"], checkpoint_to_v)
 
     def __append_build_snippets(self):
         with open(NINJA_TRANSFORM_TOOLS_PATH / "phys_netlist_build.ninja.mustache") as f:

--- a/bfasst/utils/general.py
+++ b/bfasst/utils/general.py
@@ -1,22 +1,23 @@
 """Utility functions"""
 
-from argparse import ArgumentParser
 import atexit
 import code
+import enum
 import json
 import logging
 import os
-from pathlib import Path
 import re
 import readline
 import rlcompleter
-import sys
 import shutil
-import enum
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
 
 from jpype.types import JString
-from bfasst.paths import DESIGNS_PATH
+
 from bfasst.config import BUILD
+from bfasst.paths import DESIGNS_PATH
 
 
 class TermColor:
@@ -225,14 +226,45 @@ def ensure(x, y):
     return x if x is not None else y
 
 
-def json_write_if_changed(path, json_str):
-    """Write the json file for the tool, if the new string
-    does not match the json already in existence."""
-    json_equivalent = compare_json(path, json_str)
+def normalize(data):
+    """Recursively normalize containers to dict, str, list, None, int, bool types"""
+    if data is None or not data:
+        return data
+    elif isinstance(data, (str, int, bool)):
+        return data
+    elif isinstance(data, dict):
+        return {str(k): normalize(v) for k, v in data.items()}
+    elif isinstance(data, (list, tuple, set)):
+        return [normalize(v) for v in data]
+    else:
+        return str(data)
 
-    if not json_equivalent:
-        with open(path, "w") as f:
-            f.write(json_str)
+
+def json_write_if_changed(old_data: Path, new_data):
+    """
+    Write the json file for the tool, if the new data
+    does not match the json already in existence.
+
+    Calls normalize() on new_data to ensure json serialization compatibility.
+
+    old_data (Path): The path to the old json file
+    new_data: The new data to write to the json file if it is different from the old data
+
+    Returns (bool, normalized data): A tuple indicating whether the file was written and the normalized data
+    """
+    normalized = normalize(new_data)
+    old_json = None
+    if old_data.exists():
+        with open(old_data, "r") as f:
+            old_json = json.load(f)
+
+    if old_json == normalized:
+        return False, normalized
+
+    with open(old_data, "w") as f:
+        json.dump(normalized, f, indent=4)
+
+    return True, normalized
 
 
 def get_family_from_part(part):

--- a/bfasst/utils/general.py
+++ b/bfasst/utils/general.py
@@ -227,7 +227,7 @@ def ensure(x, y):
 
 
 def normalize(data):
-    """Recursively normalize to dict, str, list, None, int, bool types"""
+    """Recursively normalize containers to dict, str, list, None, int, bool types"""
     if data is None or not data:
         return data
     if isinstance(data, (str, int, bool)):
@@ -249,7 +249,7 @@ def json_write_if_changed(old_data: Path, new_data):
     old_data (Path): The path to the old json file
     new_data: The new data to write to the json file if it is different from the old data
 
-    Returns (bool, normalized data): A tuple indicating whether the file was written and the normalized data
+    Returns (bool, normalized data): A tuple indicating whether the file was written and data
     """
     normalized = normalize(new_data)
     old_json = None

--- a/bfasst/utils/general.py
+++ b/bfasst/utils/general.py
@@ -227,17 +227,16 @@ def ensure(x, y):
 
 
 def normalize(data):
-    """Recursively normalize containers to dict, str, list, None, int, bool types"""
+    """Recursively normalize to dict, str, list, None, int, bool types"""
     if data is None or not data:
         return data
-    elif isinstance(data, (str, int, bool)):
+    if isinstance(data, (str, int, bool)):
         return data
-    elif isinstance(data, dict):
+    if isinstance(data, dict):
         return {str(k): normalize(v) for k, v in data.items()}
-    elif isinstance(data, (list, tuple, set)):
+    if isinstance(data, (list, tuple, set)):
         return [normalize(v) for v in data]
-    else:
-        return str(data)
+    return str(data)
 
 
 def json_write_if_changed(old_data: Path, new_data):

--- a/bfasst/utils/transform/netlist_obfuscate.py
+++ b/bfasst/utils/transform/netlist_obfuscate.py
@@ -8,7 +8,6 @@ import argparse
 import logging
 import pathlib
 import time
-import json
 import uuid
 from collections import defaultdict
 from bfasst.config import PART
@@ -269,7 +268,7 @@ def obfuscate_cell_properties(netlist: EDIFNetlist, out_path: str) -> int:
                     obf_count += 1
 
     print_obfuscation_summary(counts_all, counts, obf_count)
-    json_write_if_changed(out_path, json.dumps(cells_json, indent=2))
+    json_write_if_changed(out_path, cells_json)
     return obf_count
 
 

--- a/test/scripts/test_ninja_flow_manager.py
+++ b/test/scripts/test_ninja_flow_manager.py
@@ -8,24 +8,25 @@
 # import subprocess
 # import time
 import unittest
-from bfasst.flows.vivado_wafove import VivadoWafove
 
-# from bfasst.flows.flow_utils import get_flows
-from bfasst.paths import (
-    DESIGNS_PATH,
-    NINJA_BUILD_PATH,
-    # ROOT_PATH,
-)
+from bfasst.flows.impl_obfuscate import ImplObfuscate
+from bfasst.flows.ninja_flow_manager import NinjaFlowManager, get_design_basenames
 from bfasst.flows.vivado import Vivado
 from bfasst.flows.vivado_bit_analysis import VivadoBitAnalysis
+from bfasst.flows.vivado_conformal import VivadoConformal
 from bfasst.flows.vivado_phys_netlist import VivadoPhysNetlist
 from bfasst.flows.vivado_phys_netlist_cmp import VivadoPhysNetlistCmp
-from bfasst.flows.vivado_structural_error_injection import VivadoStructuralErrorInjection
-from bfasst.flows.vivado_conformal import VivadoConformal
+from bfasst.flows.vivado_structural_error_injection import (
+    VivadoStructuralErrorInjection,
+)
+from bfasst.flows.vivado_wafove import VivadoWafove
 from bfasst.flows.vivado_yosys_cmp import VivadoYosysCmp
-from bfasst.flows.impl_obfuscate import ImplObfuscate
 
-from bfasst.flows.ninja_flow_manager import NinjaFlowManager, get_design_basenames
+# from bfasst.flows.flow_utils import get_flows
+from bfasst.paths import (  # ROOT_PATH,
+    DESIGNS_PATH,
+    NINJA_BUILD_PATH,
+)
 
 
 class TestNinjaFlowManager(unittest.TestCase):
@@ -96,43 +97,43 @@ class TestNinjaFlowManager(unittest.TestCase):
         self.assertEqual(build_statement_count, correct_num_build_statements)
 
     def test_run_vivado_flow(self):
-        self.__check_flow_run("vivado", 12)
+        self.__check_flow_run("vivado", 4)
 
     def test_run_vivado_ooc_flow(self):
-        self.__check_flow_run("vivado_ooc", 11)
+        self.__check_flow_run("vivado_ooc", 3)
 
     def test_run_vivado_reversed_flow(self):
-        self.__check_flow_run("vivado_bit_analysis", 16)
+        self.__check_flow_run("vivado_bit_analysis", 8)
 
     def test_run_vivado_bit_to_netlist(self):
-        self.__check_flow_run("vivado_bit_to_netlist", 14)
+        self.__check_flow_run("vivado_bit_to_netlist", 6)
 
     def test_run_vivado_phys_netlist_flow(self):
-        self.__check_flow_run("vivado_phys_netlist", 15)
+        self.__check_flow_run("vivado_phys_netlist", 7)
 
     def test_run_phys_compare_flow(self):
-        self.__check_flow_run("vivado_phys_netlist_cmp", 19)
+        self.__check_flow_run("vivado_phys_netlist_cmp", 11)
 
     def test_run_cmp_error_injection_flow(self):
         # There should be 200 injections and 200 comparisons for one flow
         # plus all the build statements for the phys_reversed_flow
         # ((200 * 2)) + 11 = 411 build statements
-        self.__check_flow_run("vivado_structural_error_injection", 417)
+        self.__check_flow_run("vivado_structural_error_injection", 409)
 
     def test_run_vivado_conformal_flow(self):
-        self.__check_flow_run("vivado_conformal", 15)
+        self.__check_flow_run("vivado_conformal", 7)
 
     def test_run_vivado_yosys_impl_flow(self):
-        self.__check_flow_run("vivado_yosys_cmp", 16)
+        self.__check_flow_run("vivado_yosys_cmp", 8)
 
     def test_run_vivado_wafove_flow(self):
-        self.__check_flow_run("vivado_wafove", 15)
-    
+        self.__check_flow_run("vivado_wafove", 7)
+
     def test_run_vivado_phys_capnp_flow(self):
-        self.__check_flow_run("vivado_phys_capnp", 15)
+        self.__check_flow_run("vivado_phys_capnp", 7)
 
     def test_run_impl_obfuscate(self):
-        self.__check_flow_run("impl_obfuscate", 24)
+        self.__check_flow_run("impl_obfuscate", 12)
 
     # This is disabled right now because it seems to be failing due
     # to file modification time race conditions


### PR DESCRIPTION
Remove build calls for chevron template generation for Vivado tool. 

1) chevron does not have an optimized binary so bash chevron calls just launch the python interpreter and then call the chevron python script. 
2) Involves a lot of redundant file i/o - the template json is often read from disk twice. Once when generating flows with json_write_if_changed, and then again by template build step if the json has changed. This results in a lot of overhead and often if the json has changed then the python file that generates ninja.build has changed too. So it makes sense to just call the chevron template command when the json change is detected.

Starting from an empty build directory, here is the benchmarks for having template as a build step vs just templating during ninja.build configuration.
```
$time python scripts/run.py tests/weekly/vivado_all.yaml  # 177 designs

ninja template time
real    0m2.111s
user    1m25.471s
sys     2m43.711s

vs sequential python templating
real    0m0.650s
user    0m0.440s
sys     0m0.210s
```
Notice the high sys utilization from increased file i/o. So although the ninja template commands happen in parallel, sequentially generating in python is still faster.

Lastly, there was a redundant dependency in the rand_soc flow. Vivado synthesis just uses the rand_soc generated script, but all the default vivado synthesis scripts were still being templated and all the rand_soc vivado jobs still depended on these, even though they aren't used.